### PR TITLE
Fix install command

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -15,6 +15,7 @@ class InstallCommand extends Command
     {
         $this->comment('Publishing NativePHP Service Provider...');
         $this->callSilent('vendor:publish', ['--tag' => 'nativephp-provider']);
+        $this->callSilent('vendor:publish', ['--tag' => 'nativephp-config']);
 
         if ($this->option('force') || $this->confirm('Would you like to install the NativePHP NPM dependencies?', true)) {
             $this->installNpmDependencies();


### PR DESCRIPTION
When executing the native:install command, the default nativephp.php configuration file was not published to the config folder.