### PR TITLE
Fix the issue of starting the development server

### DIFF
--- a/src/Commands/DevelopCommand.php
+++ b/src/Commands/DevelopCommand.php
@@ -43,7 +43,7 @@ class DevelopCommand extends Command
                 'NATIVE_PHP_SKIP_QUEUE' => $this->option('no-queue') ? true : false,
             ])
             ->forever()
-            ->tty()
+            ->tty(PHP_OS_FAMILY != 'Windows')
             ->run('yarn run dev', function (string $type, string $output) {
                 if ($this->getOutput()->isVerbose()) {
                     echo $output;


### PR DESCRIPTION
This PR fixes the **TTY mode is not supported on Windows platform.** error.