### PR TITLE
Fix native:build on MacOS

### DIFF
--- a/resources/js/package.json
+++ b/resources/js/package.json
@@ -19,8 +19,8 @@
     "publish:linux": "cross-env npm run build && cross-env electron-builder -p always --linux --config",
     "build:win": "cross-env npm run build && cross-env electron-builder -p never --win --config",
     "build:mac": "cross-env npm run build:mac-arm && cross-env npm run build:mac-x86",
-    "build:mac-arm": "cross-env node php.js --arm64 && cross-env npm run build && cross-env electron-builder -p never --mac --config --arm64",
-    "build:mac-x86": "cross-env node php.js --x64 && cross-env npm run build && cross-env electron-builder -p never --mac --config --x64",
+    "build:mac-arm": "cross-env npm run build && cross-env electron-builder -p never --mac --config --arm64",
+    "build:mac-x86": "cross-env npm run build && cross-env electron-builder -p never --mac --config --x64",
     "build:linux": "cross-env npm run build && cross-env electron-builder -p never --linux --config"
   },
   "dependencies": {


### PR DESCRIPTION
php.js doesn't exist in this context.