### PR TITLE
Update electron-builder.js

### DIFF
--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -12,10 +12,11 @@ const appUrl = process.env.APP_URL;
 const appAuthor = process.env.NATIVEPHP_APP_AUTHOR;
 const phpBinaryPath = process.env.NATIVEPHP_PHP_BINARY_PATH;
 const certificatePath = process.env.NATIVEPHP_CERTIFICATE_FILE_PATH;
+const platformType = process.platform;
 const isArm64 = process.argv.includes('--arm64');
-const isWindows = process.argv.includes('--win');
-const isLinux = process.argv.includes('--linux');
-const isDarwin = process.argv.includes('--mac');
+const isWindows = platformType === "win32";
+const isLinux = platformType === "linux";
+const isDarwin = platformType === "darwin";
 let targetOs = 'mac';
 let phpBinaryFilename = 'php';
 if (isWindows) {

--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -17,7 +17,10 @@ const isArm64 = process.argv.includes('--arm64');
 const isWindows = platformType === "win32";
 const isLinux = platformType === "linux";
 const isDarwin = platformType === "darwin";
-let targetOs = 'mac';
+let targetOs = null;
+if(isDarwin) {
+    targetOs = 'mac';
+}
 let phpBinaryFilename = 'php';
 if (isWindows) {
     targetOs = 'win';


### PR DESCRIPTION
- Added platformType variable to store the current platform type
- Updated isWindows, isLinux, and isDarwin variables to use platformType instead of process.argv.includes()
- Updated phpBinaryFilename variable to use 'php' as the default value if isWindows is true