### PR TITLE
Linux extra condition for electron builder.

### DIFF
--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -14,7 +14,7 @@ const phpBinaryPath = process.env.NATIVEPHP_PHP_BINARY_PATH;
 const certificatePath = process.env.NATIVEPHP_CERTIFICATE_FILE_PATH;
 const isArm64 = process.argv.includes('--arm64');
 const isWindows = process.argv.includes('--win');
-const isLinux = process.argv.includes('--linux');
+const isLinux = process.argv.includes('--linux') || 'linux' === os.platform();
 const isDarwin = process.argv.includes('--mac');
 let targetOs = 'mac';
 let phpBinaryFilename = 'php';


### PR DESCRIPTION
To begin with, thank you so much for your hard work. This is an a fantasticep for the PHP community!

This is not meant to be the final solution, but it solves the problem pointed out at this issue: https://github.com/NativePHP/electron/issues/55

After briefly checking the code, I cou't find any place to trigger the npm post-installation to have the option `--linux`. Due to that, an extra check for the platform was needed for the initial script to copy the binary from Linux folder. 

The same fix might be needed for Windows.