### PR TITLE
Fix php path in queue command

### DIFF
--- a/src/Commands/QueueWorkerCommand.php
+++ b/src/Commands/QueueWorkerCommand.php
@@ -29,7 +29,7 @@ class QueueWorkerCommand extends Command
     {
         $this->info('Starting NativePHP queue worker…');
 
-        $phpBinary = __DIR__.'/../../resources/js/resources/php';
+        $phpBinary = __DIR__.'/../../resources/js/resources/php/php';
 
         Process::path(base_path())
             ->env([


### PR DESCRIPTION
Fix php path in queue command. It is pointing to the directory, not the php binary