### PR TITLE
Resolve Windows opening config file in default application

### DIFF
--- a/resources/js/package.json
+++ b/resources/js/package.json
@@ -11,7 +11,7 @@
     "start": "electron-vite preview",
     "dev": "electron-vite dev --watch",
     "build": "electron-vite build",
-    "postinstall": "electron-builder install-app-deps",
+    "postinstall": "node electron-builder install-app-deps",
     "publish:win": "cross-env npm run build && cross-env electron-builder -p always --win --config",
     "publish:mac": "cross-env npm run build:mac-arm && cross-env npm run build:mac-x86",
     "publish:mac-arm": "cross-env npm run build && cross-env electron-builder -p always --mac --config --arm64 -p always",


### PR DESCRIPTION
Windows 10 and 11 will sometimes open the electron-builder.js file in the default application during native:install or native:serve this ensure it's processed correctly.

I confirmed it has no impact on Mac.

It also needs either #47 or #52 to fully resolve Windows builds.