### PR TITLE
App Icon command

### DIFF
--- a/src/Commands/IconCommand.php
+++ b/src/Commands/IconCommand.php
@@ -10,7 +10,7 @@ use function Laravel\Prompts\note;
 class IconCommand extends Command
 {
     protected $signature = 'native:icon {path=resources/icon.png : The path to your application\'s icon}';
-    
+
     protected $description = 'A command to set your app icon. By default, it will look for `resources/icon.png`.
         Make sure your icon is at least 1024px x 1024px';
 
@@ -18,6 +18,7 @@ class IconCommand extends Command
     {
         if (! file_exists($path = $this->argument('path'))) {
             error("No icon file exists at `{$path}`");
+
             return Command::INVALID;
         }
 

--- a/src/Commands/IconCommand.php
+++ b/src/Commands/IconCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Native\Electron\Commands;
+
+use Illuminate\Console\Command;
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\note;
+
+class IconCommand extends Command
+{
+    protected $signature = 'native:icon {path=resources/icon.png : The path to your application\'s icon}';
+    
+    protected $description = 'A command to set your app icon. By default, it will look for `resources/icon.png`.
+        Make sure your icon is at least 1024px x 1024px';
+
+    public function handle()
+    {
+        if (! file_exists($path = $this->argument('path'))) {
+            error("No icon file exists at `{$path}`");
+            return Command::INVALID;
+        }
+
+        intro('Copying app icon...');
+
+        @copy($path, __DIR__.'/../../resources/js/resources/icon.png');
+
+        note('App icon copied');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/ElectronServiceProvider.php
+++ b/src/ElectronServiceProvider.php
@@ -4,6 +4,7 @@ namespace Native\Electron;
 
 use Native\Electron\Commands\BuildCommand;
 use Native\Electron\Commands\DevelopCommand;
+use Native\Electron\Commands\IconCommand;
 use Native\Electron\Commands\InstallCommand;
 use Native\Electron\Commands\PublishCommand;
 use Native\Electron\Commands\QueueWorkerCommand;
@@ -24,6 +25,7 @@ class ElectronServiceProvider extends PackageServiceProvider
                 BuildCommand::class,
                 PublishCommand::class,
                 QueueWorkerCommand::class,
+                IconCommand::class,
             ]);
     }
 


### PR DESCRIPTION
Allows you to copy your app icon into the appropriate location for Electron to pick it up and use it

Make sure your icon is a square PNG and at least 1024px x 1024px

## Usage
```shell
php artisan native:icon
```

This will look for `resources/icon.png` in your application.

Alternatively, you can specify a path:

```shell
php artisan native:icon public/app-icon.png
```