### PR TITLE
Allow compiling packages in a CI environment

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -12,7 +12,7 @@ class BuildCommand extends Command
 {
     use LocatesPhpBinary;
 
-    protected $signature = 'native:build {os=all : The operating system to build for (all, linux, mac, windows)}';
+    protected $signature = 'native:build {os=all : The operating system to build for (all, linux, mac, windows)} {--ci : Whether the build is running in a CI environment}';
 
     public function handle()
     {
@@ -31,7 +31,7 @@ class BuildCommand extends Command
         Process::path(__DIR__.'/../../resources/js/')
             ->env($this->getEnvironmentVariables())
             ->forever()
-            ->tty(PHP_OS_FAMILY != 'Windows')
+            ->tty(PHP_OS_FAMILY != 'Windows' && !$this->option('ci'))
             ->run($buildCommand, function (string $type, string $output) {
                 echo $output;
             });

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -12,7 +12,7 @@ class BuildCommand extends Command
 {
     use LocatesPhpBinary;
 
-    protected $signature = 'native:build {os=all : The operating system to build for (all, linux, mac, windows)} {--ci : Whether the build is running in a CI environment}';
+    protected $signature = 'native:build {os=all : The operating system to build for (all, linux, mac, windows)} {--no-interaction : Whether interaction should be disabled}';
 
     public function handle()
     {
@@ -31,7 +31,7 @@ class BuildCommand extends Command
         Process::path(__DIR__.'/../../resources/js/')
             ->env($this->getEnvironmentVariables())
             ->forever()
-            ->tty(PHP_OS_FAMILY != 'Windows' && !$this->option('ci'))
+            ->tty(PHP_OS_FAMILY != 'Windows' && !$this->option('no-interaction'))
             ->run($buildCommand, function (string $type, string $output) {
                 echo $output;
             });

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -12,7 +12,7 @@ class BuildCommand extends Command
 {
     use LocatesPhpBinary;
 
-    protected $signature = 'native:build {os=all : The operating system to build for (all, linux, mac, windows)} {--no-interaction : Whether interaction should be disabled}';
+    protected $signature = 'native:build {os=all : The operating system to build for (all, linux, mac, windows)}';
 
     public function handle()
     {

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -12,7 +12,7 @@ class InstallCommand extends Command
 {
     use Installer;
 
-    protected $signature = 'native:install {--force : Overwrite existing files by default} {--installer=npm : The package installer to use: npm, yarn or pnpm} {--no-interaction : Whether interaction should be disabled}';
+    protected $signature = 'native:install {--force : Overwrite existing files by default} {--installer=npm : The package installer to use: npm, yarn or pnpm}';
 
     protected $description = 'Install all of the NativePHP resources';
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -12,7 +12,7 @@ class InstallCommand extends Command
 {
     use Installer;
 
-    protected $signature = 'native:install {--force : Overwrite existing files by default} {--installer=npm : The package installer to use: npm, yarn or pnpm} {--ci : Whether the build is running in a CI environment}';
+    protected $signature = 'native:install {--force : Overwrite existing files by default} {--installer=npm : The package installer to use: npm, yarn or pnpm} {--no-interaction : Whether interaction should be disabled}';
 
     protected $description = 'Install all of the NativePHP resources';
 
@@ -20,16 +20,16 @@ class InstallCommand extends Command
     {
         intro('Publishing NativePHP Service Provider...');
 
-        $isCI = $this->option('ci');
+        $withoutInteraction = $this->option('no-interaction');
 
         $this->callSilent('vendor:publish', ['--tag' => 'nativephp-provider']);
         $this->callSilent('vendor:publish', ['--tag' => 'nativephp-config']);
 
-        $installer = $this->getInstaller($this->option('installer'), $isCI);
+        $installer = $this->getInstaller($this->option('installer'), $withoutInteraction);
 
-        $this->installNPMDependencies(force: $this->option('force'), installer: $installer, isCI: $isCI);
+        $this->installNPMDependencies(force: $this->option('force'), installer: $installer, withoutInteraction: $withoutInteraction);
 
-        $shouldPromptForServe = ! $isCI && ! $this->option('force');
+        $shouldPromptForServe = ! $withoutInteraction && ! $this->option('force');
 
         if ($shouldPromptForServe && confirm('Would you like to start the NativePHP development server', false)) {
             $this->call('native:serve', ['--installer' => $installer]);

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -12,21 +12,26 @@ class InstallCommand extends Command
 {
     use Installer;
 
-    protected $signature = 'native:install {--force : Overwrite existing files by default} {--installer=npm : The package installer to use: npm, yarn or pnpm}';
+    protected $signature = 'native:install {--force : Overwrite existing files by default} {--installer=npm : The package installer to use: npm, yarn or pnpm} {--ci : Whether the build is running in a CI environment}';
 
     protected $description = 'Install all of the NativePHP resources';
 
     public function handle(): void
     {
         intro('Publishing NativePHP Service Provider...');
+
+        $isCI = $this->option('ci');
+
         $this->callSilent('vendor:publish', ['--tag' => 'nativephp-provider']);
         $this->callSilent('vendor:publish', ['--tag' => 'nativephp-config']);
 
-        $installer = $this->getInstaller($this->option('installer'));
+        $installer = $this->getInstaller($this->option('installer'), $isCI);
 
-        $this->installNPMDependencies(force: $this->option('force'), installer: $installer);
+        $this->installNPMDependencies(force: $this->option('force'), installer: $installer, isCI: $isCI);
 
-        if (! $this->option('force') && confirm('Would you like to start the NativePHP development server', false)) {
+        $shouldPromptForServe = ! $isCI && ! $this->option('force');
+
+        if ($shouldPromptForServe && confirm('Would you like to start the NativePHP development server', false)) {
             $this->call('native:serve', ['--installer' => $installer]);
         }
 

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -12,7 +12,7 @@ class PublishCommand extends Command
 {
     use LocatesPhpBinary;
 
-    protected $signature = 'native:publish {os=mac}';
+    protected $signature = 'native:publish {os=mac} {--ci : Whether the build is running in a CI environment}';
 
     public function handle()
     {
@@ -33,7 +33,7 @@ class PublishCommand extends Command
         Process::path(__DIR__.'/../../resources/js/')
             ->env($this->getEnvironmentVariables())
             ->forever()
-            ->tty(PHP_OS_FAMILY != 'Windows')
+            ->tty(PHP_OS_FAMILY != 'Windows' && !$this->option('ci'))
             ->run('npm run publish:mac-arm', function (string $type, string $output) {
                 echo $output;
             });

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -12,7 +12,7 @@ class PublishCommand extends Command
 {
     use LocatesPhpBinary;
 
-    protected $signature = 'native:publish {os=mac} {--ci : Whether the build is running in a CI environment}';
+    protected $signature = 'native:publish {os=mac} {--no-interaction : Whether interaction should be disabled}';
 
     public function handle()
     {
@@ -33,7 +33,7 @@ class PublishCommand extends Command
         Process::path(__DIR__.'/../../resources/js/')
             ->env($this->getEnvironmentVariables())
             ->forever()
-            ->tty(PHP_OS_FAMILY != 'Windows' && !$this->option('ci'))
+            ->tty(PHP_OS_FAMILY != 'Windows' && !$this->option('no-interaction'))
             ->run('npm run publish:mac-arm', function (string $type, string $output) {
                 echo $output;
             });

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -12,7 +12,7 @@ class PublishCommand extends Command
 {
     use LocatesPhpBinary;
 
-    protected $signature = 'native:publish {os=mac} {--no-interaction : Whether interaction should be disabled}';
+    protected $signature = 'native:publish {os=mac}';
 
     public function handle()
     {

--- a/src/Traits/ExecuteCommand.php
+++ b/src/Traits/ExecuteCommand.php
@@ -10,10 +10,8 @@ trait ExecuteCommand
 {
     use LocatesPhpBinary;
 
-    protected function executeCommand(string $command, bool $skip_queue = false, string $type = 'install', bool $tty = true): void
+    protected function executeCommand(string $command, bool $skip_queue = false, string $type = 'install', bool $isCI = false): void
     {
-        $tty = $tty || PHP_OS_FAMILY != 'Windows';
-
         $envs = [
             'install' => [
                 'NATIVEPHP_PHP_BINARY_PATH' => base_path($this->phpBinaryPath()),
@@ -31,7 +29,7 @@ trait ExecuteCommand
         Process::path(__DIR__.'/../../resources/js/')
             ->env($envs[$type])
             ->forever()
-            ->tty($tty)
+            ->tty(!$isCI && PHP_OS_FAMILY != 'Windows')
             ->run($command, function (string $type, string $output) {
                 if ($this->getOutput()->isVerbose()) {
                     echo $output;

--- a/src/Traits/ExecuteCommand.php
+++ b/src/Traits/ExecuteCommand.php
@@ -10,7 +10,7 @@ trait ExecuteCommand
 {
     use LocatesPhpBinary;
 
-    protected function executeCommand(string $command, bool $skip_queue = false, string $type = 'install', bool $isCI = false): void
+    protected function executeCommand(string $command, bool $skip_queue = false, string $type = 'install', bool $withoutInteraction = false): void
     {
         $envs = [
             'install' => [
@@ -29,7 +29,7 @@ trait ExecuteCommand
         Process::path(__DIR__.'/../../resources/js/')
             ->env($envs[$type])
             ->forever()
-            ->tty(!$isCI && PHP_OS_FAMILY != 'Windows')
+            ->tty(!$withoutInteraction && PHP_OS_FAMILY != 'Windows')
             ->run($command, function (string $type, string $output) {
                 if ($this->getOutput()->isVerbose()) {
                     echo $output;

--- a/src/Traits/ExecuteCommand.php
+++ b/src/Traits/ExecuteCommand.php
@@ -10,8 +10,10 @@ trait ExecuteCommand
 {
     use LocatesPhpBinary;
 
-    protected function executeCommand(string $command, bool $skip_queue = false, string $type = 'install'): void
+    protected function executeCommand(string $command, bool $skip_queue = false, string $type = 'install', bool $tty = true): void
     {
+        $tty = $tty || PHP_OS_FAMILY != 'Windows';
+
         $envs = [
             'install' => [
                 'NATIVEPHP_PHP_BINARY_PATH' => base_path($this->phpBinaryPath()),
@@ -29,7 +31,7 @@ trait ExecuteCommand
         Process::path(__DIR__.'/../../resources/js/')
             ->env($envs[$type])
             ->forever()
-            ->tty(PHP_OS_FAMILY != 'Windows')
+            ->tty($tty)
             ->run($command, function (string $type, string $output) {
                 if ($this->getOutput()->isVerbose()) {
                     echo $output;

--- a/src/Traits/Installer.php
+++ b/src/Traits/Installer.php
@@ -11,26 +11,28 @@ trait Installer
 {
     use ExecuteCommand;
 
-    protected function installNPMDependencies(bool $force, ?string $installer = 'npm'): void
+    protected function installNPMDependencies(bool $force, ?string $installer = 'npm', bool $isCI = false): void
     {
-        if ($force || confirm('Would you like to install the NativePHP NPM dependencies?', true)) {
+        $shouldPrompt = $force || $isCI;
+
+        if ($shouldPrompt || confirm('Would you like to install the NativePHP NPM dependencies?', true)) {
             note('Installing NPM dependencies (This may take a while)...');
 
             if (! $installer) {
-                $this->installDependencies();
+                $this->installDependencies(isCI: $isCI);
             } else {
-                $this->installDependencies(installer: $installer);
+                $this->installDependencies(installer: $installer, isCI: $isCI);
             }
             $this->output->newLine();
         }
     }
 
-    protected function installDependencies(?string $installer): void
+    protected function installDependencies(?string $installer = null, bool $isCI = false): void
     {
         [$installer, $command] = $this->getInstallerAndCommand(installer: $installer);
 
         note("Installing NPM dependencies using the {$installer} package manager...");
-        $this->executeCommand(command: $command);
+        $this->executeCommand(command: $command, isCI: $isCI);
     }
 
     protected function getInstallerAndCommand(?string $installer, $type = 'install'): array

--- a/src/Traits/Installer.php
+++ b/src/Traits/Installer.php
@@ -11,28 +11,28 @@ trait Installer
 {
     use ExecuteCommand;
 
-    protected function installNPMDependencies(bool $force, ?string $installer = 'npm', bool $isCI = false): void
+    protected function installNPMDependencies(bool $force, ?string $installer = 'npm', bool $withoutInteraction = false): void
     {
-        $shouldPrompt = $force || $isCI;
+        $shouldPrompt = $force || $withoutInteraction;
 
         if ($shouldPrompt || confirm('Would you like to install the NativePHP NPM dependencies?', true)) {
             note('Installing NPM dependencies (This may take a while)...');
 
             if (! $installer) {
-                $this->installDependencies(isCI: $isCI);
+                $this->installDependencies(withoutInteraction: $withoutInteraction);
             } else {
-                $this->installDependencies(installer: $installer, isCI: $isCI);
+                $this->installDependencies(installer: $installer, withoutInteraction: $withoutInteraction);
             }
             $this->output->newLine();
         }
     }
 
-    protected function installDependencies(?string $installer = null, bool $isCI = false): void
+    protected function installDependencies(?string $installer = null, bool $withoutInteraction = false): void
     {
         [$installer, $command] = $this->getInstallerAndCommand(installer: $installer);
 
         note("Installing NPM dependencies using the {$installer} package manager...");
-        $this->executeCommand(command: $command, isCI: $isCI);
+        $this->executeCommand(command: $command, withoutInteraction: $withoutInteraction);
     }
 
     protected function getInstallerAndCommand(?string $installer, $type = 'install'): array


### PR DESCRIPTION
Currently, we're unable to compile a NativePHP application in a CI environment (ie GitHub Actions) because dev/tty is not writable.

This change introduces a new `--ci` flag to the following commands:

- native:install
- native:build
- native:publish

This fixes https://github.com/NativePHP/laravel/issues/179 and allows compiling in a CI environment