### PR TITLE
fixing typo in binaryArch in php.js

### DIFF
--- a/resources/js/php.js
+++ b/resources/js/php.js
@@ -16,7 +16,7 @@ if (isLinux) {
     os = 'linux';
 }
 
-let binaryArch = 'x64';
+let binaryArch = 'x86';
 if (isArm64) {
     binaryArch = 'arm64';
 }


### PR DESCRIPTION
Due to (likely) a typo, default arch is set to x64, so that php artisan native:build is failing (at least on mac silicon).