### PR TITLE
windows extra condition for electron builder.

### DIFF
--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -13,7 +13,7 @@ const appAuthor = process.env.NATIVEPHP_APP_AUTHOR;
 const phpBinaryPath = process.env.NATIVEPHP_PHP_BINARY_PATH;
 const certificatePath = process.env.NATIVEPHP_CERTIFICATE_FILE_PATH;
 const isArm64 = process.argv.includes('--arm64');
-const isWindows = process.argv.includes('--win');
+const isWindows = process.argv.includes('--win') || 'win32' === os.platform();
 const isLinux = process.argv.includes('--linux') || 'linux' === os.platform();
 const isDarwin = process.argv.includes('--mac');
 let targetOs = 'mac';


### PR DESCRIPTION
Without this condition, when we run "php artisan native:serve" on a Windows OS, it copies the PHP binary from the Mac folder instead of the Windows folder. This occurs because the "isWindows" condition is false, and we never receive a "--win" argument in the "process.argv" array when serving the app. Comparing "win32" from the "os.platform()" method fixes this issue.