### PR TITLE
Fix undefined class Process in ExampleTest.php

### DIFF
--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Symfony\Component\Process\PhpExecutableFinder;
+use Illuminate\Support\Facades\Process;
 
 it('can boot up the app', function () {
     $executableFinder = new PhpExecutableFinder();
@@ -11,7 +12,7 @@ it('can boot up the app', function () {
         to: base_path('artisan'),
     );
 
-    $process = \Illuminate\Support\Facades\Process::path(base_path())
+    $process = Process::path(base_path())
         ->tty()
         ->start($php.' artisan native:serve', function ($type, $line) {
             echo $line;


### PR DESCRIPTION
Process was undefined because it was not imported.
```php
    try {
        retry(12, function () {
            // Wait until port 8100 is open
            dump('Waiting for port 8100 to open...');
            $fp = @fsockopen('localhost', 8100, $errno, $errstr, 1);
            if ($fp === false) {
                throw new Exception('Port 8100 is not open yet');
            }
        }, 5000);
    } catch (Exception $e) {
        Process::run('pkill -9 -P '.$process->id()); //Undefined
        throw $e;
    }
    Process::run('pkill -9 -P '.$process->id()); //Undefined
```
But used here : 

```php
    $process = \Illuminate\Support\Facades\Process::path(base_path())
```