### PR TITLE
Fix callSilent disabling future output

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -23,8 +23,8 @@ class InstallCommand extends Command
 
         $withoutInteraction = $this->option('no-interaction');
 
-        $this->callSilent('vendor:publish', ['--tag' => 'nativephp-provider']);
-        $this->callSilent('vendor:publish', ['--tag' => 'nativephp-config']);
+        $this->call('vendor:publish', ['--tag' => 'nativephp-provider']);
+        $this->call('vendor:publish', ['--tag' => 'nativephp-config']);
 
         $installer = $this->getInstaller($this->option('installer'), $withoutInteraction);
 


### PR DESCRIPTION
For some reason callSilent() is unable to revert from the silent state and all questions after it are not shown, so disable for now.