### PR TITLE
Fixed missing import of select() function from Laravel Prompts

### DIFF
--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use Native\Electron\Concerns\LocatesPhpBinary;
 use Native\Electron\Facades\Updater;
+use function Laravel\Prompts\select;
 
 class PublishCommand extends Command
 {


### PR DESCRIPTION
I was trying to run the `native:publish` command when I encountered the following error:

```
In PublishCommand.php line 34:

  Call to undefined function Native\Electron\Commands\select()
  
```

So I imported the right function from Laravel Prompts to make it work.