### PR TITLE
fix: add missing platform.arch for Linux and Windows

### DIFF
--- a/resources/js/php.js
+++ b/resources/js/php.js
@@ -26,10 +26,12 @@ const platform = {
 if (isWindows) {
     platform.os = 'win';
     platform.phpBinary += '.exe';
+    platform.arch = 'x64';
 }
 
 if (isLinux) {
     platform.os = 'linux';
+    platform.arch = 'x64';
 }
 
 if (isDarwin) {


### PR DESCRIPTION
Fix regression from:
https://github.com/NativePHP/electron/commit/ab99e94ed49b27e5b5cd16f8668fcad882611d47