### PR TITLE
Add environment variable for php bin directory.

### DIFF
--- a/src/Concerns/LocatesPhpBinary.php
+++ b/src/Concerns/LocatesPhpBinary.php
@@ -9,7 +9,7 @@ trait LocatesPhpBinary
      */
     protected function binaryPackageDirectory(): string
     {
-        return env('NATIVEPHP_PHP_BINARY_PACKAGE_DIR', 'vendor/nativephp/php-bin/');
+        return env('NATIVEPHP_PHP_BINARY_PATH', 'vendor/nativephp/php-bin/');
     }
 
     /**

--- a/src/Concerns/LocatesPhpBinary.php
+++ b/src/Concerns/LocatesPhpBinary.php
@@ -9,7 +9,7 @@ trait LocatesPhpBinary
      */
     protected function binaryPackageDirectory(): string
     {
-        return 'vendor/nativephp/php-bin/';
+        return env('NATIVEPHP_PHP_BINARY_PACKAGE_DIR', 'vendor/nativephp/php-bin/');
     }
 
     /**


### PR DESCRIPTION
Noticed that the php-bin binary path is hardcoded. This isn't great if people need to compile their own versions for needing specific extensions like Zip or Xml. This allows users to set an environment variable to overwrite that.