### PR TITLE
Updated @nativephp/electron-plugin to v0.5.1

### DIFF
--- a/resources/js/package-lock.json
+++ b/resources/js/package-lock.json
@@ -12,7 +12,7 @@
                 "@electron-toolkit/preload": "^3.0.1",
                 "@electron-toolkit/utils": "^3.0.0",
                 "@electron/remote": "^2.0.9",
-                "@nativephp/electron-plugin": "^0.5.0",
+                "@nativephp/electron-plugin": "^0.5.1",
                 "yauzl": "^3.1.3"
             },
             "devDependencies": {
@@ -1441,9 +1441,9 @@
             }
         },
         "node_modules/@nativephp/electron-plugin": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@nativephp/electron-plugin/-/electron-plugin-0.5.0.tgz",
-            "integrity": "sha512-OOU+OLMcJf491Gp5r6yGiUtBPwT1OxHwlIcVoBI9gqm5iNU/M2Yl66kzKEyaVOTZ3ijQvOcdUnKlJNGCHUWs5Q==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@nativephp/electron-plugin/-/electron-plugin-0.5.1.tgz",
+            "integrity": "sha512-sNqtb6W+j6jNR/UYNneHi86AlKQq+pT2yXNEx5BOq4LF59szUyyw3SasN72CquJ3VX4wHu1pzehlWDHFOWx33Q==",
             "funding": [
                 {
                     "type": "github",

--- a/resources/js/package.json
+++ b/resources/js/package.json
@@ -32,7 +32,7 @@
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "@electron/remote": "^2.0.9",
-        "@nativephp/electron-plugin": "^0.5.0",
+        "@nativephp/electron-plugin": "^0.5.1",
         "yauzl": "^3.1.3"
     },
     "devDependencies": {

--- a/resources/js/yarn.lock
+++ b/resources/js/yarn.lock
@@ -393,10 +393,10 @@
     lodash "^4.17.15"
     tmp-promise "^3.0.2"
 
-"@nativephp/electron-plugin@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/@nativephp/electron-plugin/-/electron-plugin-0.5.0.tgz"
-  integrity sha512-OOU+OLMcJf491Gp5r6yGiUtBPwT1OxHwlIcVoBI9gqm5iNU/M2Yl66kzKEyaVOTZ3ijQvOcdUnKlJNGCHUWs5Q==
+"@nativephp/electron-plugin@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/@nativephp/electron-plugin/-/electron-plugin-0.5.1.tgz"
+  integrity sha512-sNqtb6W+j6jNR/UYNneHi86AlKQq+pT2yXNEx5BOq4LF59szUyyw3SasN72CquJ3VX4wHu1pzehlWDHFOWx33Q==
   dependencies:
     "@electron-toolkit/utils" "^1.0.2"
     "@electron/remote" "^2.0.9"


### PR DESCRIPTION
Following [release 0.5.1 of electron-plugin](https://github.com/NativePHP/electron-plugin/releases/tag/v0.5.1) I upped the included version here.

Can this go online as 0.7.1 or do we wait for the next "Update the NPM dependencies" release?
I couldn't find information on the current release cycle and would like to use the new features.
