### PR TITLE
App Icon version 2

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -7,12 +7,14 @@ use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use Native\Electron\Concerns\LocatesPhpBinary;
 use Native\Electron\Facades\Updater;
+use Native\Electron\Traits\InstallsAppIcon;
 use Native\Electron\Traits\OsAndArch;
 
 class BuildCommand extends Command
 {
     use LocatesPhpBinary;
     use OsAndArch;
+    use InstallsAppIcon;
 
     protected $signature = 'native:build
         {os? : The operating system to build for (all, linux, mac, win)}
@@ -40,13 +42,15 @@ class BuildCommand extends Command
         // Added checks for correct input for os and arch
         $os = $this->selectOs($this->argument('os'));
 
+        $this->installIcon();
+
         $buildCommand = 'build';
         if ($os != 'all') {
             $arch = $this->selectArchitectureForOs($os, $this->argument('arch'));
 
             $os .= $arch != 'all' ? "-{$arch}" : '';
 
-            // Wether to publish the app or not
+            // Should we publish?
             if ($publish = ($this->option('publish'))) {
                 $buildCommand = 'publish';
             }

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -12,9 +12,9 @@ use Native\Electron\Traits\OsAndArch;
 
 class BuildCommand extends Command
 {
+    use InstallsAppIcon;
     use LocatesPhpBinary;
     use OsAndArch;
-    use InstallsAppIcon;
 
     protected $signature = 'native:build
         {os? : The operating system to build for (all, linux, mac, win)}

--- a/src/Commands/DevelopCommand.php
+++ b/src/Commands/DevelopCommand.php
@@ -5,13 +5,14 @@ namespace Native\Electron\Commands;
 use Illuminate\Console\Command;
 use Native\Electron\Traits\Developer;
 use Native\Electron\Traits\Installer;
+use Native\Electron\Traits\InstallsAppIcon;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\note;
 
 class DevelopCommand extends Command
 {
-    use Developer, Installer;
+    use Developer, Installer, InstallsAppIcon;
 
     protected $signature = 'native:serve {--no-queue} {--D|no-dependencies} {--installer=npm}';
 
@@ -35,6 +36,8 @@ class DevelopCommand extends Command
         }
 
         $this->patchPackageJson();
+
+        $this->installIcon();
 
         $this->runDeveloper(installer: $this->option('installer'), skip_queue: $this->option('no-queue'));
     }

--- a/src/Traits/InstallsAppIcon.php
+++ b/src/Traits/InstallsAppIcon.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Native\Electron\Traits;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\note;
+
+trait InstallsAppIcon
+{
+    public function installIcon()
+    {
+        intro('Copying app icons...');
+
+        @copy(public_path('icon.png'), __DIR__.'/../../resources/js/resources/icon.png');
+        @copy(public_path('IconTemplate.png'), __DIR__.'/../../resources/js/resources/IconTemplate.png');
+        @copy(public_path('IconTemplate@2x.png'), __DIR__.'/../../resources/js/resources/IconTemplate@2x.png');
+
+        note('App icons copied');
+    }
+}


### PR DESCRIPTION
Replaces #72 with a simpler "just put the file in the right place" approach.

Simply put your icon in `public/icon.png` and it will be moved into the right place for Electron to do its thing.