### PR TITLE
Fix windows php path for native:minify

### DIFF
--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -1,8 +1,8 @@
-const {copySync, removeSync, writeJsonSync, existsSync} = require("fs-extra");
-const {join} = require("path");
 const os = require('os');
-const {mkdtempSync} = require("fs");
-const {execSync} = require("child_process");
+const { join } = require("path");
+const { mkdtempSync } = require("fs");
+const { copySync, removeSync, writeJsonSync } = require("fs-extra");
+
 const isBuilding = process.env.NATIVEPHP_BUILDING;
 const appId = process.env.NATIVEPHP_APP_ID;
 const appName = process.env.NATIVEPHP_APP_NAME;
@@ -108,10 +108,6 @@ if (isBuilding) {
         console.log('Copied app to resources');
         console.log(join(process.env.APP_PATH, 'dist'));
         console.log('=====================');
-
-        const artisanPath = join(appPath, 'artisan');
-        // We'll use the default PATH PHP binary here, as we can cross-compile for all platforms. This shouldn't be changed.
-        execSync(`php ${artisanPath} native:minify ${appPath}`, { cwd: appPath });
     } catch (e) {
         console.error('=====================');
         console.error('Error copying app to resources');

--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -111,7 +111,7 @@ if (isBuilding) {
 
         const artisanPath = join(appPath, 'artisan');
         // We'll use the default PATH PHP binary here, as we can cross-compile for all platforms. This shouldn't be changed.
-        execSync(`php ${artisanPath} native:minify ${appPath}`);
+        execSync(`php ${artisanPath} native:minify ${appPath}`, { cwd: appPath });
     } catch (e) {
         console.error('=====================');
         console.error('Error copying app to resources');


### PR DESCRIPTION
#### Description
In windows, `php` is getting resolved as `C:\Users\virtualbox\Downloads\laravel\api\vendor\nativephp\electron\\resources\js\php.js` instead of system `php.exe`.

#### Example:
`> where php` results in 2 php executables `php.js` and `php.exe` relative to `resources/js/electron-builder.js`. This is causing a fail in the windows build during `php artisan native:minify` step 

![image](https://github.com/user-attachments/assets/5cbfb547-1436-47f1-aa64-4808a6659812)

#### Resolves
- https://github.com/NativePHP/laravel/issues/338