### PR TITLE
Adding support for NSScreenCaptureUsageDescription

### DIFF
--- a/resources/js/electron-builder.js
+++ b/resources/js/electron-builder.js
@@ -164,6 +164,8 @@ module.exports = {
                 "Application requests access to the user's Documents folder.",
             NSDownloadsFolderUsageDescription:
                 "Application requests access to the user's Downloads folder.",
+            NSScreenCaptureUsageDescription:
+                "Application requests access to the user's screen capture and system audio",
         },
     },
     dmg: {


### PR DESCRIPTION
Adding support for NSScreenCaptureUsageDescription so that my app can capture system audio / screen recording if needed. This needs to be part of build file.