### PR TITLE
Support `--no-interaction` in `native:serve` command

### DIFF
--- a/src/Commands/DevelopCommand.php
+++ b/src/Commands/DevelopCommand.php
@@ -39,7 +39,11 @@ class DevelopCommand extends Command
 
         $this->installIcon();
 
-        $this->runDeveloper(installer: $this->option('installer'), skip_queue: $this->option('no-queue'), withoutInteraction: $this->option('no-interaction'));
+        $this->runDeveloper(
+            installer: $this->option('installer'),
+            skip_queue: $this->option('no-queue'),
+            withoutInteraction: $this->option('no-interaction')
+        );
     }
 
     /**

--- a/src/Commands/DevelopCommand.php
+++ b/src/Commands/DevelopCommand.php
@@ -25,7 +25,8 @@ class DevelopCommand extends Command
         if (! $this->option('no-dependencies')) {
             $this->installNPMDependencies(
                 force: ! $this->option('no-dependencies'),
-                installer: $this->option('installer')
+                installer: $this->option('installer'),
+                withoutInteraction: $this->option('no-interaction')
             );
         }
 

--- a/src/Traits/Developer.php
+++ b/src/Traits/Developer.php
@@ -13,6 +13,12 @@ trait Developer
         [$installer, $command] = $this->getInstallerAndCommand(installer: $installer, type: 'dev');
 
         note("Running the dev script with {$installer}...");
-        $this->executeCommand(command: $command, skip_queue: $skip_queue, type: 'serve', withoutInteraction: $withoutInteraction);
+
+        $this->executeCommand(
+            command: $command,
+            skip_queue: $skip_queue,
+            type: 'serve',
+            withoutInteraction: $withoutInteraction
+        );
     }
 }

--- a/src/Traits/ExecuteCommand.php
+++ b/src/Traits/ExecuteCommand.php
@@ -11,7 +11,12 @@ trait ExecuteCommand
 {
     use LocatesPhpBinary;
 
-    protected function executeCommand(string $command, bool $skip_queue = false, string $type = 'install', bool $withoutInteraction = false): void
+    protected function executeCommand(
+        string $command,
+        bool $skip_queue = false,
+        string $type = 'install',
+        bool $withoutInteraction = false
+    ): void
     {
         $envs = [
             'install' => [
@@ -30,6 +35,7 @@ trait ExecuteCommand
         ];
 
         note('Fetching latest dependencies…');
+
         Process::path(__DIR__.'/../../resources/js/')
             ->env($envs[$type])
             ->forever()

--- a/src/Traits/ExecuteCommand.php
+++ b/src/Traits/ExecuteCommand.php
@@ -16,8 +16,7 @@ trait ExecuteCommand
         bool $skip_queue = false,
         string $type = 'install',
         bool $withoutInteraction = false
-    ): void
-    {
+    ): void {
         $envs = [
             'install' => [
                 'NATIVEPHP_PHP_BINARY_VERSION' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,


### PR DESCRIPTION
This will allow us to run the command shelled through another command, which allows for a concurrent command like Laravel's new `composer dev` command, i.e. adding this to the `scripts` section of your `composer.json`:

```json
"scripts": {
    "native:dev": [
        "Composer\\Config::disableProcessTimeout",
        "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185\" \"php artisan native:serve --no-interaction\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=app,logs,vite"
    ]
},
```

Then you can run `composer native:dev` and get your app booted in dev mode, watch the logs with Pail (requires installation), and be running Vite for hot reloading 🔥