### PR TITLE
Add PHP server exception reporting

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/notification.js
+++ b/resources/js/electron-plugin/dist/server/api/notification.js
@@ -3,12 +3,13 @@ import { Notification } from 'electron';
 import { notifyLaravel } from "../utils";
 const router = express.Router();
 router.post('/', (req, res) => {
-    const { title, body, subtitle, silent, icon, hasReply, timeoutType, replyPlaceholder, sound, urgency, actions, closeButtonText, toastXml } = req.body;
+    const { title, body, subtitle, silent, icon, hasReply, timeoutType, replyPlaceholder, sound, urgency, actions, closeButtonText, toastXml, customEvent: event } = req.body;
+    const eventName = customEvent !== null && customEvent !== void 0 ? customEvent : '\\Native\\Laravel\\Events\\Notifications\\NotificationClicked';
     const notification = new Notification({ title, body, subtitle, silent, icon, hasReply, timeoutType, replyPlaceholder, sound, urgency, actions, closeButtonText, toastXml });
     notification.on("click", (event) => {
         notifyLaravel('events', {
-            event: '\\Native\\Laravel\\Events\\Notifications\\NotificationClicked',
-            payload: []
+            event: eventName,
+            payload: JSON.stringify(event)
         });
     });
     notification.show();

--- a/resources/js/electron-plugin/dist/server/php.js
+++ b/resources/js/electron-plugin/dist/server/php.js
@@ -211,6 +211,7 @@ function serveApp(secret, apiPort, phpIniSettings) {
                     console.error('  ' + error.slice(47));
                     console.log('Please check your log file:');
                     console.log('  ' + join(appPath, 'storage', 'logs', 'laravel.log'));
+                    console.log();
                 }
             }
         });

--- a/resources/js/electron-plugin/dist/server/php.js
+++ b/resources/js/electron-plugin/dist/server/php.js
@@ -194,7 +194,8 @@ function serveApp(secret, apiPort, phpIniSettings) {
             }
         });
         phpServer.stderr.on('data', (data) => {
-            const match = portRegex.exec(data.toString());
+            const error = data.toString();
+            const match = portRegex.exec(error);
             if (match) {
                 const port = parseInt(match[1]);
                 console.log("PHP Server started on port: ", port);
@@ -202,6 +203,15 @@ function serveApp(secret, apiPort, phpIniSettings) {
                     port,
                     process: phpServer
                 });
+            }
+            else {
+                if (error.startsWith('[NATIVE_EXCEPTION]: ', 27)) {
+                    console.log();
+                    console.error('Error in PHP:');
+                    console.error('  ' + error.slice(47));
+                    console.log('Please check your log file:');
+                    console.log('  ' + join(appPath, 'storage', 'logs', 'laravel.log'));
+                }
             }
         });
         phpServer.on('error', (error) => {

--- a/resources/js/electron-plugin/src/server/php.ts
+++ b/resources/js/electron-plugin/src/server/php.ts
@@ -256,6 +256,7 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
                     console.error('  ' + error.slice(47));
                     console.log('Please check your log file:');
                     console.log('  ' + join(appPath, 'storage', 'logs', 'laravel.log'));
+                    console.log();
                 }
             }
         });

--- a/resources/js/electron-plugin/src/server/php.ts
+++ b/resources/js/electron-plugin/src/server/php.ts
@@ -238,16 +238,27 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
         })
 
         phpServer.stderr.on('data', (data) => {
-            const match = portRegex.exec(data.toString())
+            const error = data.toString();
+            const match = portRegex.exec(error);
+
             if (match) {
-                const port = parseInt(match[1])
-                console.log("PHP Server started on port: ", port)
+                const port = parseInt(match[1]);
+                console.log("PHP Server started on port: ", port);
                 resolve({
                     port,
                     process: phpServer
-                })
+                });
+            } else {
+                // 27 is the length of the php -S output preamble
+                if (error.startsWith('[NATIVE_EXCEPTION]: ', 27)) {
+                    console.log();
+                    console.error('Error in PHP:');
+                    console.error('  ' + error.slice(47));
+                    console.log('Please check your log file:');
+                    console.log('  ' + join(appPath, 'storage', 'logs', 'laravel.log'));
+                }
             }
-        })
+        });
 
         phpServer.on('error', (error) => {
             reject(error)

--- a/resources/js/yarn.lock
+++ b/resources/js/yarn.lock
@@ -11,18 +11,18 @@
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.0.tgz"
-  integrity sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==
+  version "7.26.2"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz"
+  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.25.9"
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.25.9", "@babel/compat-data@^7.26.0":
-  version "7.26.0"
-  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.0.tgz"
-  integrity sha512-qETICbZSLe7uXv9VE8T/RWOdIE5qqyTucOt4zLYMafj2MRO271VGgLd4RACJMeBO37UPWhXiKMBk7YlJ0fOzQA==
+  version "7.26.2"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz"
+  integrity sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==
 
 "@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.0.0-0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.11.6", "@babel/core@^7.12.0", "@babel/core@^7.12.3", "@babel/core@^7.13.0", "@babel/core@^7.23.9", "@babel/core@^7.24.7", "@babel/core@^7.4.0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.8.0", "@babel/core@>=7.0.0-beta.0 <8":
   version "7.26.0"
@@ -46,11 +46,11 @@
     semver "^6.3.1"
 
 "@babel/generator@^7.25.9", "@babel/generator@^7.26.0", "@babel/generator@^7.7.2":
-  version "7.26.0"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.26.0.tgz"
-  integrity sha512-/AIkAmInnWwgEAJGQr9vY0c66Mj6kjkE2ZPB1PurTRaRAh3U+J45sAQMjQDJdh4WbR3l0x5xkimXBKyBXXAu2w==
+  version "7.26.2"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz"
+  integrity sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==
   dependencies:
-    "@babel/parser" "^7.26.0"
+    "@babel/parser" "^7.26.2"
     "@babel/types" "^7.26.0"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
@@ -218,10 +218,10 @@
     "@babel/template" "^7.25.9"
     "@babel/types" "^7.26.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.25.3", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0":
-  version "7.26.1"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.26.1.tgz"
-  integrity sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.25.3", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.2":
+  version "7.26.2"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz"
+  integrity sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==
   dependencies:
     "@babel/types" "^7.26.0"
 
@@ -1032,9 +1032,9 @@
   integrity sha512-GaXHDhiT7KCvMJjXdp/QqpYinq69T/Pdl49Z1XLf8mKGf63dnsODMWyrmIjEQ0z/vG7dO8qF3fvmI6Eb2lUNZA==
 
 "@electron/asar@^3.2.1":
-  version "3.2.14"
-  resolved "https://registry.npmjs.org/@electron/asar/-/asar-3.2.14.tgz"
-  integrity sha512-hc52QkesULqbxTRC1vOmSBN1YndUkieoNMfvpe988h0MEoGGqbijkOqv4/2M9PufBJxiTVoDdBmBFfXPowZDQg==
+  version "3.2.15"
+  resolved "https://registry.npmjs.org/@electron/asar/-/asar-3.2.15.tgz"
+  integrity sha512-AerUbRZpkDVRs58WP32t4U2bx85sfwRkQI8RMIEi6s2NBE++sgjsgAAMtXvnfTISKUkXo386pxFW7sa7WtMCrw==
   dependencies:
     commander "^5.0.0"
     glob "^7.1.6"
@@ -1718,16 +1718,16 @@
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
 "@types/node@*", "@types/node@^18.7.6", "@types/node@>= 14":
-  version "18.19.61"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.19.61.tgz"
-  integrity sha512-z8fH66NcVkDzBItOao+Nyh0fiy7CYdxIyxnNCcZ60aY0I+EA/y4TSi/S/W9i8DIQvwVo7a0pgzAxmDeNnqrpkw==
+  version "18.19.62"
+  resolved "https://registry.npmjs.org/@types/node/-/node-18.19.62.tgz"
+  integrity sha512-UOGhw+yZV/icyM0qohQVh3ktpY40Sp7tdTW7HxG3pTd7AiMrlFlAJNUrGK9t5mdW0+ViQcFV74zCSIx9ZJpncA==
   dependencies:
     undici-types "~5.26.4"
 
 "@types/node@^20.9.0":
-  version "20.17.3"
-  resolved "https://registry.npmjs.org/@types/node/-/node-20.17.3.tgz"
-  integrity sha512-tSQrmKKatLDGnG92h40GD7FzUt0MjahaHwOME4VAFeeA/Xopayq5qLyQRy7Jg/pjgKIFBXuKcGhJo+UdYG55jQ==
+  version "20.17.4"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.17.4.tgz"
+  integrity sha512-Fi1Bj8qTJr4f1FDdHFR7oMlOawEYSzkHNdBJK+aRjcDDNHwEV3jPPjuZP2Lh2QNgXeqzM8Y+U6b6urKAog2rZw==
   dependencies:
     undici-types "~6.19.2"
 
@@ -2459,7 +2459,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.23.3, browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0, browserslist@^4.24.2, "browserslist@>= 4.21.0":
   version "4.24.2"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz"
   integrity sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==
@@ -2608,9 +2608,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001669:
-  version "1.0.30001674"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001674.tgz"
-  integrity sha512-jOsKlZVRnzfhLojb+Ykb+gyUSp9Xb57So+fAiFlLzzTKpqg8xxSav0e40c8/4F/v9N8QSvrRRaLeVzQbLqomYw==
+  version "1.0.30001676"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001676.tgz"
+  integrity sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==
 
 chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.2:
   version "4.1.2"
@@ -2792,11 +2792,11 @@ copy-anything@^2.0.1:
     is-what "^3.14.1"
 
 core-js-compat@^3.38.0, core-js-compat@^3.38.1:
-  version "3.38.1"
-  resolved "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz"
-  integrity sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==
+  version "3.39.0"
+  resolved "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz"
+  integrity sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==
   dependencies:
-    browserslist "^4.23.3"
+    browserslist "^4.24.2"
 
 core-util-is@~1.0.0, core-util-is@1.0.2:
   version "1.0.2"
@@ -6764,9 +6764,9 @@ truncate-utf8-bytes@^1.0.0:
     utf8-byte-length "^1.0.1"
 
 ts-api-utils@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz"
-  integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.0.tgz"
+  integrity sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==
 
 ts-jest@^29.2.5:
   version "29.2.5"


### PR DESCRIPTION
Explicitly render exceptions reported via the `php -S`'s `STDERR` so that they are visible to the developer when running debug builds.

Requires https://github.com/NativePHP/laravel/pull/398