### PR TITLE
Make the queue worker work

### DIFF
--- a/resources/js/electron-plugin/src/server/php.ts
+++ b/resources/js/electron-plugin/src/server/php.ts
@@ -135,7 +135,7 @@ function startQueueWorker(secret, apiPort, phpIniSettings = {}) {
         env
     };
 
-    return callPhp(['artisan', 'queue:work'], phpOptions, phpIniSettings);
+    return callPhp(['artisan', 'queue:work', '-q'], phpOptions, phpIniSettings);
 }
 
 function startScheduler(secret, apiPort, phpIniSettings = {}) {


### PR DESCRIPTION
This appears to be the simplest solution to https://github.com/NativePHP/laravel/issues/346.

For some reason (which I'm not 100% clear on), the queue worker doesn't like it when its `STDOUT` output isn't piped somewhere, and after a lot of work in rapid succession it just silently falls over.

However, when we explicitly handle its output - or, in this case, prevent it from trying to send output altogether by passing the `-q|--quiet` option - it runs continuously just fine.