### PR TITLE
MenuBar improvements

### DIFF
--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -62,6 +62,7 @@ router.post("/create", (req, res) => {
         windowPosition,
         contextMenu,
         tooltip,
+        resizable,
     } = req.body;
 
     if (onlyShowContextMenu) {
@@ -91,6 +92,7 @@ router.post("/create", (req, res) => {
             browserWindow: {
                 width,
                 height,
+                resizable,
                 alwaysOnTop,
                 vibrancy,
                 backgroundColor,

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -71,11 +71,22 @@ router.post("/create", (req, res) => {
         contextMenu,
         tooltip,
         resizable,
+        event,
     } = req.body;
 
     if (onlyShowContextMenu) {
         const tray = new Tray(icon || state.icon.replace("icon.png", "IconTemplate.png"));
+
         tray.setContextMenu(buildMenu(contextMenu));
+
+        if (event) {
+            tray.on('click', (e) => {
+                notifyLaravel('events', {
+                    event,
+                    payload: e,
+                });
+            });
+        }
 
         state.activeMenuBar = menubar({
             tray,

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -107,6 +107,7 @@ router.post("/create", (req, res) => {
                 backgroundColor,
                 transparent: transparency,
                 webPreferences: {
+                    preload: join(__dirname, '../../electron-plugin/dist/preload/index.js'),
                     nodeIntegration: true,
                     sandbox: false,
                     contextIsolation: false,

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -16,6 +16,14 @@ router.post("/label", (req, res) => {
     state.activeMenuBar.tray.setTitle(label);
 });
 
+router.post("/tooltip", (req, res) => {
+    res.sendStatus(200);
+
+    const { tooltip } = req.body;
+
+    state.activeMenuBar.tray.setToolTip(tooltip);
+});
+
 router.post("/context-menu", (req, res) => {
     res.sendStatus(200);
 
@@ -53,6 +61,7 @@ router.post("/create", (req, res) => {
         onlyShowContextMenu,
         windowPosition,
         contextMenu,
+        tooltip,
     } = req.body;
 
     if (onlyShowContextMenu) {
@@ -61,6 +70,7 @@ router.post("/create", (req, res) => {
 
         state.activeMenuBar = menubar({
             tray,
+            tooltip,
             index: false,
             showDockIcon,
             showOnAllWorkspaces: false,
@@ -73,6 +83,7 @@ router.post("/create", (req, res) => {
     } else {
         state.activeMenuBar = menubar({
             icon: icon || state.icon.replace("icon.png", "IconTemplate.png"),
+            tooltip,
             index: url,
             showDockIcon,
             showOnAllWorkspaces: false,

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -92,6 +92,7 @@ router.post("/create", (req, res) => {
     } else {
         state.activeMenuBar = menubar({
             icon: icon || state.icon.replace("icon.png", "IconTemplate.png"),
+            preloadWindow: true,
             tooltip,
             index: url,
             showDockIcon,

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -24,6 +24,14 @@ router.post("/tooltip", (req, res) => {
     state.activeMenuBar.tray.setToolTip(tooltip);
 });
 
+router.post("/icon", (req, res) => {
+    res.sendStatus(200);
+
+    const { icon } = req.body;
+
+    state.activeMenuBar.tray.setImage(icon);
+});
+
 router.post("/context-menu", (req, res) => {
     res.sendStatus(200);
 

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -9,138 +9,139 @@ import { join } from "path";
 const router = express.Router();
 
 router.post("/label", (req, res) => {
-  res.sendStatus(200);
+    res.sendStatus(200);
 
-  const { label } = req.body;
+    const { label } = req.body;
 
-  state.activeMenuBar.tray.setTitle(label);
+    state.activeMenuBar.tray.setTitle(label);
 });
 
 router.post("/context-menu", (req, res) => {
-  res.sendStatus(200);
-  const { contextMenu } = req.body;
-  
-  state.activeMenuBar.tray.setContextMenu(buildMenu(contextMenu));
+    res.sendStatus(200);
+
+    const { contextMenu } = req.body;
+
+    state.activeMenuBar.tray.setContextMenu(buildMenu(contextMenu));
 });
 
 router.post("/show", (req, res) => {
-  res.sendStatus(200);
+    res.sendStatus(200);
 
-  state.activeMenuBar.showWindow();
+    state.activeMenuBar.showWindow();
 });
 
 router.post("/hide", (req, res) => {
-  res.sendStatus(200);
+    res.sendStatus(200);
 
-  state.activeMenuBar.hideWindow();
+    state.activeMenuBar.hideWindow();
 });
 
 router.post("/create", (req, res) => {
-  res.sendStatus(200);
+    res.sendStatus(200);
 
-  const {
-    width,
-    height,
-    url,
-    label,
-    alwaysOnTop,
-    vibrancy,
-    backgroundColor,
-    transparency,
-    icon,
-    showDockIcon,
-    onlyShowContextWindow,
-    windowPosition,
-    contextMenu
-  } = req.body;
-
-  if (onlyShowContextWindow === true) {
-    const tray = new Tray(icon || state.icon.replace("icon.png", "IconTemplate.png"));
-    tray.setContextMenu(buildMenu(contextMenu));
-
-    state.activeMenuBar = menubar({
-      tray,
-      index: false,
-      showDockIcon,
-      showOnAllWorkspaces: false,
-      browserWindow: {
-        show: false,
-        width: 0,
-        height: 0,
-      }
-    });
-
-  } else {
-    state.activeMenuBar = menubar({
-      icon: icon || state.icon.replace("icon.png", "IconTemplate.png"),
-      index: url,
-      showDockIcon,
-      showOnAllWorkspaces: false,
-      windowPosition: windowPosition ?? "trayCenter",
-      browserWindow: {
+    const {
         width,
         height,
+        url,
+        label,
         alwaysOnTop,
         vibrancy,
         backgroundColor,
-        transparent: transparency,
-        webPreferences: {
-          nodeIntegration: true,
-          sandbox: false,
-          contextIsolation: false
-        }
-      }
-    });
-    state.activeMenuBar.on("after-create-window", () => {
-      require("@electron/remote/main").enable(state.activeMenuBar.window.webContents);
-    });
-  }
+        transparency,
+        icon,
+        showDockIcon,
+        onlyShowContextWindow,
+        windowPosition,
+        contextMenu,
+    } = req.body;
 
-  state.activeMenuBar.on("ready", () => {
-    state.activeMenuBar.tray.setTitle(label);
+    if (onlyShowContextWindow) {
+        const tray = new Tray(icon || state.icon.replace("icon.png", "IconTemplate.png"));
+        tray.setContextMenu(buildMenu(contextMenu));
 
-    state.activeMenuBar.on("hide", () => {
-      notifyLaravel("events", {
-        event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarHidden"
-      });
-    });
-
-    state.activeMenuBar.on("show", () => {
-      notifyLaravel("events", {
-        event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarShown"
-      });
-    });
-
-    state.activeMenuBar.tray.on("drop-files", (event, files) => {
-      notifyLaravel("events", {
-        event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarDroppedFiles",
-        payload: [
-          files
-        ]
-      });
-    });
-
-    if (onlyShowContextWindow !== true) {
-      state.activeMenuBar.tray.on("right-click", () => {
-        notifyLaravel("events", {
-          event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarContextMenuOpened"
+        state.activeMenuBar = menubar({
+            tray,
+            index: false,
+            showDockIcon,
+            showOnAllWorkspaces: false,
+            browserWindow: {
+                show: false,
+                width: 0,
+                height: 0,
+            }
+        });
+    } else {
+        state.activeMenuBar = menubar({
+            icon: icon || state.icon.replace("icon.png", "IconTemplate.png"),
+            index: url,
+            showDockIcon,
+            showOnAllWorkspaces: false,
+            windowPosition: windowPosition ?? "trayCenter",
+            browserWindow: {
+                width,
+                height,
+                alwaysOnTop,
+                vibrancy,
+                backgroundColor,
+                transparent: transparency,
+                webPreferences: {
+                    nodeIntegration: true,
+                    sandbox: false,
+                    contextIsolation: false,
+                }
+            }
         });
 
-        state.activeMenuBar.tray.popUpContextMenu(buildMenu(contextMenu));
-      });
+        state.activeMenuBar.on("after-create-window", () => {
+            require("@electron/remote/main").enable(state.activeMenuBar.window.webContents);
+        });
     }
-  });
+
+    state.activeMenuBar.on("ready", () => {
+        state.activeMenuBar.tray.setTitle(label);
+
+        state.activeMenuBar.on("hide", () => {
+            notifyLaravel("events", {
+                event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarHidden"
+            });
+        });
+
+        state.activeMenuBar.on("show", () => {
+            notifyLaravel("events", {
+                event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarShown"
+            });
+        });
+
+        state.activeMenuBar.tray.on("drop-files", (event, files) => {
+            notifyLaravel("events", {
+                event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarDroppedFiles",
+                payload: [
+                    files
+                ]
+            });
+        });
+
+        if (! onlyShowContextWindow) {
+            state.activeMenuBar.tray.on("right-click", () => {
+                notifyLaravel("events", {
+                    event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarContextMenuOpened"
+                });
+
+                state.activeMenuBar.tray.popUpContextMenu(buildMenu(contextMenu));
+            });
+        }
+    });
 });
 
 function buildMenu(contextMenu) {
-  let menu = Menu.buildFromTemplate([{ role: "quit" }]);
+    let menu = Menu.buildFromTemplate([{ role: "quit" }]);
 
-  if (contextMenu) {
-    const menuEntries = contextMenu.map(mapMenu);
-    menu = Menu.buildFromTemplate(menuEntries);
-  }
+    if (contextMenu) {
+        const menuEntries = contextMenu.map(mapMenu);
+        menu = Menu.buildFromTemplate(menuEntries);
+    }
 
-  return menu;
+    return menu;
 }
 
 export default router;

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -50,12 +50,12 @@ router.post("/create", (req, res) => {
         transparency,
         icon,
         showDockIcon,
-        onlyShowContextWindow,
+        onlyShowContextMenu,
         windowPosition,
         contextMenu,
     } = req.body;
 
-    if (onlyShowContextWindow) {
+    if (onlyShowContextMenu) {
         const tray = new Tray(icon || state.icon.replace("icon.png", "IconTemplate.png"));
         tray.setContextMenu(buildMenu(contextMenu));
 
@@ -121,7 +121,7 @@ router.post("/create", (req, res) => {
             });
         });
 
-        if (! onlyShowContextWindow) {
+        if (! onlyShowContextMenu) {
             state.activeMenuBar.tray.on("right-click", () => {
                 notifyLaravel("events", {
                     event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarContextMenuOpened"


### PR DESCRIPTION
Currently, MenuBar windows are limited in what they're capable of:

- Some settings can't be changed once they've been created, such as the [icon](https://github.com/orgs/NativePHP/discussions/142).
- The window itself doesn't have the same controls as other windows (e.g. they are always user-resizable and [can't be made a fixed size](https://github.com/orgs/NativePHP/discussions/159)).
- Some features aren't exposed, such as tooltip text.
- The window doesn't receive any events from Electron or Laravel, making it impossible to use our Native events in JS or Livewire.
- Context menus or MenuBar windows are the only option, there's no support for [custom logic](https://github.com/orgs/NativePHP/discussions/246).

This PR aims to fix all of these issues. It also defaults to preloading the window (when there is one) so that it is visible much sooner after the user clicks on the icon, making for a much better UX.