### PR TITLE
Fix some MenuBar quirks

### DIFF
--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -160,15 +160,15 @@ router.post("/create", (req, res) => {
             });
         });
 
-        if (! onlyShowContextMenu) {
-            state.activeMenuBar.tray.on("right-click", () => {
-                notifyLaravel("events", {
-                    event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarContextMenuOpened"
-                });
-
-                state.activeMenuBar.tray.popUpContextMenu(buildMenu(contextMenu));
+        state.activeMenuBar.tray.on("right-click", () => {
+            notifyLaravel("events", {
+                event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarContextMenuOpened"
             });
-        }
+
+            if (! onlyShowContextMenu) {
+                state.activeMenuBar.tray.popUpContextMenu(buildMenu(contextMenu));
+            }
+        });
     });
 });
 

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -113,6 +113,7 @@ router.post("/create", (req, res) => {
             showDockIcon,
             showOnAllWorkspaces: false,
             windowPosition: windowPosition ?? "trayCenter",
+            activateWithApp: false,
             browserWindow: {
                 width,
                 height,

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -55,6 +55,10 @@ router.post("/hide", (req, res) => {
 router.post("/create", (req, res) => {
     res.sendStatus(200);
 
+    if (state.activeMenuBar) {
+        return;
+    }
+
     const {
         width,
         height,


### PR DESCRIPTION
Some quirks that this fixes:

- When using `showDockIcon` and not `onlyShowContextMenu`, if you click the dock icon, the menu bar will activate _even if your app has other windows that will show_
- This event also duplicates the icon on Mac (really recreating the MenuBar)
- If you do set `onlyShowContextMenu`, we stopped sending the right-click event to Laravel