### PR TITLE
MenuBars continued

### DIFF
--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -83,19 +83,6 @@ router.post("/create", (req, res) => {
 
         tray.setContextMenu(buildMenu(contextMenu));
 
-        if (event) {
-            tray.on('click', (combo, bounds, position) => {
-                notifyLaravel('events', {
-                    event,
-                    payload: {
-                        combo,
-                        bounds,
-                        position,
-                    },
-                });
-            });
-        }
-
         state.activeMenuBar = menubar({
             tray,
             tooltip,
@@ -164,14 +151,40 @@ router.post("/create", (req, res) => {
             });
         });
 
-        state.activeMenuBar.tray.on("right-click", () => {
+        state.activeMenuBar.tray.on('click', (combo, bounds, position) => {
+            notifyLaravel('events', {
+                event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarClicked",
+                payload: {
+                    combo,
+                    bounds,
+                    position,
+                },
+            });
+        });
+
+        state.activeMenuBar.tray.on("right-click", (combo, bounds) => {
             notifyLaravel("events", {
-                event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarContextMenuOpened"
+                event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarRightClicked",
+                payload: {
+                    combo,
+                    bounds,
+                }
             });
 
             if (! onlyShowContextMenu) {
+                state.activeMenuBar.hideWindow();
                 state.activeMenuBar.tray.popUpContextMenu(buildMenu(contextMenu));
             }
+        });
+
+        state.activeMenuBar.tray.on('double-click', (combo, bounds) => {
+            notifyLaravel('events', {
+                event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarDoubleClicked",
+                payload: {
+                    combo,
+                    bounds,
+                },
+            });
         });
     });
 });

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -56,7 +56,7 @@ router.post("/create", (req, res) => {
     res.sendStatus(200);
 
     if (state.activeMenuBar) {
-        return;
+        state.activeMenuBar.tray.destroy();
     }
 
     const {


### PR DESCRIPTION
- Allow future calls to the menu bar to recreate it
- Support more events in a standard way
- Hide the popover when right-clicking to show the context menu