### PR TITLE
Fixes and improvements to powerMonitor

### DIFF
--- a/resources/js/electron-plugin/src/server/api/powerMonitor.ts
+++ b/resources/js/electron-plugin/src/server/api/powerMonitor.ts
@@ -4,8 +4,10 @@ import { notifyLaravel } from '../utils';
 const router = express.Router();
 
 router.get('/get-system-idle-state', (req, res) => {
+    let threshold = Number(req.query.threshold) || 60;
+
     res.json({
-        result: powerMonitor.getSystemIdleState(req.body.threshold),
+        result: powerMonitor.getSystemIdleState(threshold),
     })
 });
 

--- a/resources/js/electron-plugin/src/server/api/powerMonitor.ts
+++ b/resources/js/electron-plugin/src/server/api/powerMonitor.ts
@@ -67,4 +67,42 @@ powerMonitor.addListener('speed-limit-change', (details) => {
     });
 })
 
+// @ts-ignore
+powerMonitor.addListener('lock-screen', () => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\ScreenLocked`,
+    });
+})
+
+// @ts-ignore
+powerMonitor.addListener('unlock-screen', () => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\ScreenUnlocked`,
+    });
+})
+
+
+// @ts-ignore
+powerMonitor.addListener('shutdown', () => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\Shutdown`,
+    });
+})
+
+
+// @ts-ignore
+powerMonitor.addListener('user-did-become-active', () => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\UserDidBecomeActive`,
+    });
+})
+
+
+// @ts-ignore
+powerMonitor.addListener('user-did-resign-active', () => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\UserDidResignActive`,
+    });
+})
+
 export default router;


### PR DESCRIPTION
Several fixes and improvements (with https://github.com/NativePHP/laravel/pull/445)

- [x] Fix powerMonitor.getSystemIdleState() not working  
-  [x] Add events for `lock-screen`, `unlock-screen`, `shutdown`, `user-did-become-active`, and `user-did-resign-active` as they are useful for checking the IdleState without constantly polling
-  [x] Add a testing mock

----- 

The power monitor facade is really useful, especially for our battery-powered computers. 

It just needs some refinement, which is the purpose of this PR.

Here is an example usage:
<img width="600" alt="Capture d’écran 2024-12-11 à 15 00 43" src="https://github.com/user-attachments/assets/057305c4-3982-4668-bd16-a2fe15420e06" />


