### PR TITLE
Add support for window.show()

### DIFF
--- a/resources/js/electron-plugin/src/server/api/window.ts
+++ b/resources/js/electron-plugin/src/server/api/window.ts
@@ -108,6 +108,16 @@ router.post('/hide', (req, res) => {
     return res.sendStatus(200);
 });
 
+router.post('/show', (req, res) => {
+    const { id } = req.body;
+
+    if (state.windows[id]) {
+        state.windows[id].show();
+    }
+
+    return res.sendStatus(200);
+});
+
 router.post('/always-on-top', (req, res) => {
     const {id, alwaysOnTop} = req.body;
 

--- a/resources/js/electron-plugin/tests/endpoints/window.test.ts
+++ b/resources/js/electron-plugin/tests/endpoints/window.test.ts
@@ -1,0 +1,39 @@
+import startAPIServer, { APIProcess } from "../../src/server/api";
+import axios from "axios";
+import electron from "electron";
+
+let apiServer: APIProcess;
+
+jest.mock('electron', () => ({
+    ...jest.requireActual('electron'),
+
+    window: {
+        hide: jest.fn(),
+        show: jest.fn(),
+    }
+}));
+
+describe('Window test', () => {
+  beforeEach(async () => {
+    apiServer = await startAPIServer('randomSecret')
+
+    axios.defaults.baseURL = `http://localhost:${apiServer.port}/api`;
+    axios.defaults.headers.common['x-nativephp-secret'] = 'randomSecret';
+  })
+
+  afterEach(done => {
+    apiServer.server.close(done);
+  });
+
+  it('can hide a window', async () => {
+    const response = await axios.post('/window/hide');
+    expect(response.status).toBe(200);
+    // expect(electron.window.show).toHaveBeenCalled();
+  });
+
+  it('can show a window', async () => {
+    const response = await axios.post('/window/show');
+    expect(response.status).toBe(200);
+    // expect(electron.window.show).toHaveBeenCalled();
+  });
+});

--- a/resources/js/electron-plugin/tests/endpoints/window.test.ts
+++ b/resources/js/electron-plugin/tests/endpoints/window.test.ts
@@ -1,17 +1,18 @@
 import startAPIServer, { APIProcess } from "../../src/server/api";
 import axios from "axios";
-import electron from "electron";
+import state from "../../src/server/state";
 
 let apiServer: APIProcess;
 
-jest.mock('electron', () => ({
-    ...jest.requireActual('electron'),
-
-    window: {
-        hide: jest.fn(),
-        show: jest.fn(),
+jest.mock('../../src/server/state', () => ({
+    ...jest.requireActual('../../src/server/state'),
+    windows: {
+        main: {
+            hide: jest.fn(),
+            show: jest.fn(),
+        },
     }
-}));
+}))
 
 describe('Window test', () => {
   beforeEach(async () => {
@@ -26,14 +27,14 @@ describe('Window test', () => {
   });
 
   it('can hide a window', async () => {
-    const response = await axios.post('/window/hide');
+    const response = await axios.post('/window/hide', { id: 'main' });
     expect(response.status).toBe(200);
-    // expect(electron.window.show).toHaveBeenCalled();
+    expect(state.windows.main.hide).toHaveBeenCalled();
   });
 
   it('can show a window', async () => {
-    const response = await axios.post('/window/show');
+    const response = await axios.post('/window/show', { id: 'main' });
     expect(response.status).toBe(200);
-    // expect(electron.window.show).toHaveBeenCalled();
+    expect(state.windows.main.show).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR adds support for showing windows (I'll open the necessary PR in the NativePHP/laravel repo soon). I tried adding tests to match the dialog and clipboard tests, but I couldn't figure out why I was getting an error when I tried asserting a method was called.

Here's the error in case you have suggestions you'd like me to try:

```sh
FAIL  electron-plugin/tests/endpoints/window.test.ts
  ● Test suite failed to run

    electron-plugin/tests/endpoints/window.test.ts:36:21 - error TS2339: Property 'window' does not exist on type 'typeof CrossProcessExports'.

    36     expect(electron.window.show).toHaveBeenCalled();
```