### PR TITLE
fix: kill tree php server

### DIFF
--- a/resources/js/electron-plugin/dist/index.js
+++ b/resources/js/electron-plugin/dist/index.js
@@ -16,6 +16,7 @@ import { notifyLaravel } from "./server/utils.js";
 import { resolve } from "path";
 import { stopAllProcesses } from "./server/api/childProcess.js";
 import ps from "ps-node";
+import killSync from "kill-sync";
 import electronUpdater from 'electron-updater';
 const { autoUpdater } = electronUpdater;
 class NativePHP {
@@ -173,6 +174,7 @@ class NativePHP {
             .filter((p) => p !== undefined)
             .forEach((process) => {
             try {
+                killSync(process.pid, 'SIGTERM', true);
                 ps.kill(process.pid);
             }
             catch (err) {

--- a/resources/js/electron-plugin/src/index.ts
+++ b/resources/js/electron-plugin/src/index.ts
@@ -14,6 +14,7 @@ import { notifyLaravel } from "./server/utils.js";
 import { resolve } from "path";
 import { stopAllProcesses } from "./server/api/childProcess.js";
 import ps from "ps-node";
+import killSync from "kill-sync";
 
 // Workaround for CommonJS module
 import electronUpdater from 'electron-updater';
@@ -220,7 +221,9 @@ class NativePHP {
       .filter((p) => p !== undefined)
       .forEach((process) => {
         try {
-          ps.kill(process.pid);
+          // @ts-ignore
+          killSync(process.pid, 'SIGTERM', true); // Kill tree
+          ps.kill(process.pid); // Sometimes does not kill the subprocess of php server
         } catch (err) {
           console.error(err);
         }


### PR DESCRIPTION
For unknown reasons, PHP server child processes will persists when closing NativePHP app `CMD+Q`

It doesn't happens when using `CTRL+C` on `php artisan native:serve`. 

The only difference I see is that `CTRL+C` send an `SIGINT`, instead of a graceful `SIGTERM`.

From my research: 
- `SIGINT` for **immediate** interruption (user-driven).
- `SIGTERM` for a **graceful** termination (programmatic request).