### PR TITLE
Update logic to ensure TTY mode is appropriately disabled

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,12 +20,12 @@ jobs:
           - laravel: 10.*
             testbench: ^8.18
             carbon: ^2.67
-            laravel-package-tools: ^1.16
+            laravel-package-tools: ^1.16.4
             collision: 7.*
           - laravel: 11.*
             testbench: 9.*
             carbon: "^2.67|^3.0"
-            laravel-package-tools: ^1.16
+            laravel-package-tools: ^1.16.4
             collision: ^8.1.1
         exclude:
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "php": "^8.1",
         "illuminate/contracts": "^10.0|^11.0",
         "laravel/prompts": "^0.1.1|^0.2|^0.3",
-        "nativephp/laravel": "^1.0",
+        "nativephp/laravel": "^1.0@beta",
         "nativephp/php-bin": "^0.5.1",
         "spatie/laravel-package-tools": "^1.14.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "laravel/prompts": "^0.1.1|^0.2|^0.3",
         "nativephp/laravel": "^1.0@beta",
         "nativephp/php-bin": "^0.5.1",
-        "spatie/laravel-package-tools": "^1.14.0"
+        "spatie/laravel-package-tools": "^1.16.4"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -9,6 +9,7 @@ use Native\Electron\Concerns\LocatesPhpBinary;
 use Native\Electron\Facades\Updater;
 use Native\Electron\Traits\InstallsAppIcon;
 use Native\Electron\Traits\OsAndArch;
+use Symfony\Component\Process\Process as SymfonyProcess;
 
 class BuildCommand extends Command
 {
@@ -60,7 +61,7 @@ class BuildCommand extends Command
         Process::path(__DIR__.'/../../resources/js/')
             ->env($this->getEnvironmentVariables())
             ->forever()
-            ->tty(PHP_OS_FAMILY != 'Windows' && ! $this->option('no-interaction'))
+            ->tty(SymfonyProcess::isTtySupported() && ! $this->option('no-interaction'))
             ->run("npm run {$buildCommand}:{$os}", function (string $type, string $output) {
                 echo $output;
             });


### PR DESCRIPTION
Fixes https://github.com/NativePHP/laravel/issues/468

- Utilises the Symfony Process class which has a tried and tested `isTtySupported()` method. This will return false if windows due to a DIRECTORY_SEPARATOR check.
- Removed check for Windows specifically as this is checked as above.
- Ensures even if TTY is supported, it is still set to off when -n|--non-interactive is specified.


### Supporting Documentation:
https://symfony.com/doc/current/components/process.html#checking-for-tty-support