### PR TITLE
Expand notification api with reference and more events

### DIFF
--- a/resources/js/electron-plugin/src/server/api/notification.ts
+++ b/resources/js/electron-plugin/src/server/api/notification.ts
@@ -18,10 +18,13 @@ router.post('/', (req, res) => {
         actions,
         closeButtonText,
         toastXml,
-        event: customEvent
+        event: customEvent,
+        reference,
     } = req.body;
 
     const eventName = customEvent ?? '\\Native\\Laravel\\Events\\Notifications\\NotificationClicked';
+
+    const notificationReference = reference ?? Date.now();
 
     const notification = new Notification({
         title,
@@ -42,13 +45,50 @@ router.post('/', (req, res) => {
     notification.on("click", (event) => {
         notifyLaravel('events', {
             event: eventName,
-            payload: JSON.stringify(event)
+            payload: {
+                reference: notificationReference,
+                event: JSON.stringify(event),
+            },
+        });
+    });
+
+    notification.on("action", (event, index) => {
+        notifyLaravel('events', {
+            event: '\\Native\\Laravel\\Events\\Notifications\\NotificationActionClicked',
+            payload: {
+                reference: notificationReference,
+                index,
+                event: JSON.stringify(event),
+            },
+        });
+    });
+
+    notification.on("reply", (event, reply) => {
+        notifyLaravel('events', {
+            event: '\\Native\\Laravel\\Events\\Notifications\\NotificationReply',
+            payload: {
+                reference: notificationReference,
+                reply,
+                event: JSON.stringify(event),
+            },
+        });
+    });
+
+    notification.on("close", (event) => {
+        notifyLaravel('events', {
+            event: '\\Native\\Laravel\\Events\\Notifications\\NotificationClosed',
+            payload: {
+                reference: notificationReference,
+                event: JSON.stringify(event),
+            },
         });
     });
 
     notification.show();
 
-    res.sendStatus(200);
+    res.status(200).json({
+        reference: notificationReference,
+    });
 });
 
 export default router;

--- a/resources/js/electron-plugin/src/server/api/notification.ts
+++ b/resources/js/electron-plugin/src/server/api/notification.ts
@@ -24,7 +24,7 @@ router.post('/', (req, res) => {
 
     const eventName = customEvent ?? '\\Native\\Laravel\\Events\\Notifications\\NotificationClicked';
 
-    const notificationReference = reference ?? Date.now();
+    const notificationReference = reference ?? (Date.now() + '.' + Math.random().toString(36).slice(2, 9));
 
     const notification = new Notification({
         title,


### PR DESCRIPTION
### Changes

- Added a reference to the notifications so that you can identify which notification was clicked.

### Added

- Implemented more events for notifications: reply, action, and close.

---

Goes hand in hand with https://github.com/NativePHP/laravel/pull/498