### PR TITLE
fix: notification click event handling

### DIFF
--- a/resources/js/electron-plugin/src/server/api/notification.ts
+++ b/resources/js/electron-plugin/src/server/api/notification.ts
@@ -41,7 +41,7 @@ router.post('/', (req, res) => {
 
     notification.on("click", (event) => {
         notifyLaravel('events', {
-            event: eventName,
+            event: eventName || '\\Native\\Laravel\\Events\\Notifications\\NotificationClicked',
             payload: JSON.stringify(event)
         });
     });


### PR DESCRIPTION
If no events are specified, an error will be thrown when Electron tries to notify Laravel.