### PR TITLE
Ensure php-bin is removed from built app

### DIFF
--- a/src/Traits/PrunesVendorDirectory.php
+++ b/src/Traits/PrunesVendorDirectory.php
@@ -21,6 +21,9 @@ trait PrunesVendorDirectory
             });
 
         $filesystem = new Filesystem;
-        $filesystem->remove($this->buildPath('/vendor/bin'));
+        $filesystem->remove([
+            $this->buildPath('/vendor/bin'),
+            $this->buildPath('/vendor/nativephp/php-bin'),
+        ]);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NativePHP/laravel/issues/503

- Ensure php-bin is removed after composer has run
- Resolves notarisation issues with apple
- Reduces app size