### PR TITLE
Skip errors when copying files during build

### DIFF
--- a/src/Traits/CopiesToBuildDirectory.php
+++ b/src/Traits/CopiesToBuildDirectory.php
@@ -10,9 +10,14 @@
 namespace Native\Electron\Traits;
 
 use RecursiveCallbackFilterIterator;
+use Symfony\Component\Filesystem\Path;
+
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\Filesystem\Filesystem;
+use Throwable;
+
+use function Laravel\Prompts\warning;
 
 trait CopiesToBuildDirectory
 {
@@ -98,7 +103,11 @@ trait CopiesToBuildDirectory
                 continue;
             }
 
-            copy($item->getPathname(), $target);
+            try {
+                copy($item->getPathname(), $target);
+            } catch (Throwable $e) {
+                warning('[WARNING] ' . $e->getMessage());
+            }
         }
 
         $this->keepRequiredDirectories();

--- a/src/Traits/CopiesToBuildDirectory.php
+++ b/src/Traits/CopiesToBuildDirectory.php
@@ -10,8 +10,6 @@
 namespace Native\Electron\Traits;
 
 use RecursiveCallbackFilterIterator;
-use Symfony\Component\Filesystem\Path;
-
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\Filesystem\Filesystem;
@@ -106,7 +104,7 @@ trait CopiesToBuildDirectory
             try {
                 copy($item->getPathname(), $target);
             } catch (Throwable $e) {
-                warning('[WARNING] ' . $e->getMessage());
+                warning('[WARNING] '.$e->getMessage());
             }
         }
 


### PR DESCRIPTION
We ran into an issue while building, caused by a linked storage directory.

This works as expected on mac, but failed on windows. Symlinks do not really exist there, thus the existing conditional clauses had some unexpected behaviour.

Using symlinks is discouraged as per the docs: https://nativephp.com/docs/desktop/1/digging-deeper/files#symlinks

Pete and I had a quick call, and decided to skip (but log) whenever a copy error occurred. 

We might need to harden this further