### PR TITLE
Copy latest certificate on before build

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -14,6 +14,7 @@ use Native\Electron\Traits\LocatesPhpBinary;
 use Native\Electron\Traits\OsAndArch;
 use Native\Electron\Traits\PrunesVendorDirectory;
 use Native\Electron\Traits\SetsAppName;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
 use function Laravel\Prompts\intro;
@@ -78,6 +79,13 @@ class BuildCommand extends Command
         $this->newLine();
         intro('Copying App to build directory...');
         $this->copyToBuildDirectory();
+
+        $this->newLine();
+        intro('Copying latest CA Certificate...');
+        copy(
+            Path::join($sourcePath, 'vendor', 'nativephp', 'php-bin', 'cacert.pem'),
+            Path::join($sourcePath, 'vendor', 'nativephp', 'electron', 'resources', 'js', 'resources', 'cacert.pem')
+        );
 
         $this->newLine();
         intro('Cleaning .env file...');


### PR DESCRIPTION
It turns out the `cacert.pem` file was only copied over during the serve command. 
A build before at least running `serve` once was impossible due to the certificate not being present.

This PR adds a step to the build command to move the latest file over on every build.