### PR TITLE
Basic Build Command cleanup

### DIFF
--- a/resources/js/php.js
+++ b/resources/js/php.js
@@ -8,7 +8,6 @@ import unzip from "yauzl";
 const isBuilding = Boolean(process.env.NATIVEPHP_BUILDING);
 const phpBinaryPath = process.env.NATIVEPHP_PHP_BINARY_PATH;
 const phpVersion = process.env.NATIVEPHP_PHP_BINARY_VERSION;
-const certificatePath = process.env.NATIVEPHP_CERTIFICATE_FILE_PATH;
 
 // Differentiates for Serving and Building
 const isArm64 = isBuilding ? process.argv.includes('--arm64') : process.arch.includes('arm64');
@@ -96,15 +95,5 @@ if (platform.phpBinary) {
         });
     } catch (e) {
         console.error('Error copying PHP binary', e);
-    }
-}
-
-if (certificatePath) {
-    try {
-        let certDest = join(import.meta.dirname, 'resources', 'cacert.pem');
-        copySync(certificatePath, certDest);
-        console.log('Copied certificate file from ' + certificatePath + ' to ' + certDest);
-    } catch (e) {
-        console.error('Error copying certificate file', e);
     }
 }

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -119,7 +119,6 @@ class BuildCommand extends Command
                 'NATIVEPHP_BUILDING' => true,
                 'NATIVEPHP_PHP_BINARY_VERSION' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
                 'NATIVEPHP_PHP_BINARY_PATH' => $this->sourcePath($this->phpBinaryPath()),
-                'NATIVEPHP_CERTIFICATE_FILE_PATH' => $this->sourcePath($this->binaryPackageDirectory().'cacert.pem'),
                 'NATIVEPHP_APP_NAME' => config('app.name'),
                 'NATIVEPHP_APP_ID' => config('nativephp.app_id'),
                 'NATIVEPHP_APP_VERSION' => config('nativephp.version'),

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use Native\Electron\Facades\Updater;
 use Native\Electron\Traits\CleansEnvFile;
+use Native\Electron\Traits\CopiesCertificateAuthority;
 use Native\Electron\Traits\CopiesToBuildDirectory;
 use Native\Electron\Traits\HasPreAndPostProcessing;
 use Native\Electron\Traits\InstallsAppIcon;
@@ -22,6 +23,7 @@ use function Laravel\Prompts\intro;
 class BuildCommand extends Command
 {
     use CleansEnvFile;
+    use CopiesCertificateAuthority;
     use CopiesToBuildDirectory;
     use HasPreAndPostProcessing;
     use InstallsAppIcon;
@@ -81,11 +83,7 @@ class BuildCommand extends Command
         $this->copyToBuildDirectory();
 
         $this->newLine();
-        intro('Copying latest CA Certificate...');
-        copy(
-            Path::join($this->sourcePath(), 'vendor', 'nativephp', 'php-bin', 'cacert.pem'),
-            Path::join($this->sourcePath(), 'vendor', 'nativephp', 'electron', 'resources', 'js', 'resources', 'cacert.pem')
-        );
+        $this->copyCertificateAuthorityCertificate();
 
         $this->newLine();
         intro('Cleaning .env file...');

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -15,7 +15,6 @@ use Native\Electron\Traits\LocatesPhpBinary;
 use Native\Electron\Traits\OsAndArch;
 use Native\Electron\Traits\PrunesVendorDirectory;
 use Native\Electron\Traits\SetsAppName;
-use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
 use function Laravel\Prompts\intro;

--- a/src/Commands/DevelopCommand.php
+++ b/src/Commands/DevelopCommand.php
@@ -3,6 +3,7 @@
 namespace Native\Electron\Commands;
 
 use Illuminate\Console\Command;
+use Native\Electron\Traits\CopiesCertificateAuthority;
 use Native\Electron\Traits\Developer;
 use Native\Electron\Traits\Installer;
 use Native\Electron\Traits\InstallsAppIcon;
@@ -12,7 +13,10 @@ use function Laravel\Prompts\note;
 
 class DevelopCommand extends Command
 {
-    use Developer, Installer, InstallsAppIcon;
+    use CopiesCertificateAuthority;
+    use Developer;
+    use Installer;
+    use InstallsAppIcon;
 
     protected $signature = 'native:serve {--no-queue} {--D|no-dependencies} {--installer=npm}';
 
@@ -39,6 +43,8 @@ class DevelopCommand extends Command
         $this->patchPackageJson();
 
         $this->installIcon();
+
+        $this->copyCertificateAuthorityCertificate();
 
         $this->runDeveloper(
             installer: $this->option('installer'),

--- a/src/Traits/CopiesCertificateAuthority.php
+++ b/src/Traits/CopiesCertificateAuthority.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Native\Electron\Traits;
+
+use Symfony\Component\Filesystem\Path;
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\intro;
+
+trait CopiesCertificateAuthority
+{
+    protected function copyCertificateAuthorityCertificate(): void
+    {
+        try {
+            intro('Copying latest CA Certificate...');
+
+            $copied = copy(
+                Path::join($this->sourcePath(), 'vendor', 'nativephp', 'php-bin', 'cacert.pem'),
+                Path::join($this->sourcePath(), 'vendor', 'nativephp', 'electron', 'resources', 'js', 'resources', 'cacert.pem')
+            );
+
+            if (!$copied) {
+                // It returned false, but doesn't give a reason why.
+                throw new \Exception('copy() failed for an unknown reason.');
+            }
+        } catch (\Throwable $e) {
+            error('Failed to copy CA Certificate: '.$e->getMessage());
+        }
+    }
+}

--- a/src/Traits/CopiesCertificateAuthority.php
+++ b/src/Traits/CopiesCertificateAuthority.php
@@ -5,6 +5,7 @@ namespace Native\Electron\Traits;
 use Symfony\Component\Filesystem\Path;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
+use function Laravel\Prompts\warning;
 
 trait CopiesCertificateAuthority
 {
@@ -13,9 +14,26 @@ trait CopiesCertificateAuthority
         try {
             intro('Copying latest CA Certificate...');
 
+            $phpBinaryDirectory = base_path('vendor/nativephp/php-bin/');
+
+            // Check if the class this trait is used in also uses LocatesPhpBinary
+            if (method_exists($this, 'phpBinaryPath')) {
+                // Get binary directory but up one level
+                $phpBinaryDirectory = dirname(base_path($this->phpBinaryPath()));
+            }
+
+            $certificateFileName = 'cacert.pem';
+            $certFilePath = Path::join($phpBinaryDirectory, $certificateFileName);
+
+            if (!file_exists($certFilePath)) {
+                warning('CA Certificate not found at ' . $certFilePath . '. Skipping copy.');
+
+                return;
+            }
+
             $copied = copy(
-                Path::join($this->sourcePath(), 'vendor', 'nativephp', 'php-bin', 'cacert.pem'),
-                Path::join($this->sourcePath(), 'vendor', 'nativephp', 'electron', 'resources', 'js', 'resources', 'cacert.pem')
+                $certFilePath,
+                Path::join(base_path('vendor/nativephp/electron/resources/js/resources'), $certificateFileName)
             );
 
             if (!$copied) {

--- a/src/Traits/CopiesCertificateAuthority.php
+++ b/src/Traits/CopiesCertificateAuthority.php
@@ -3,6 +3,7 @@
 namespace Native\Electron\Traits;
 
 use Symfony\Component\Filesystem\Path;
+
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\warning;
@@ -25,8 +26,8 @@ trait CopiesCertificateAuthority
             $certificateFileName = 'cacert.pem';
             $certFilePath = Path::join($phpBinaryDirectory, $certificateFileName);
 
-            if (!file_exists($certFilePath)) {
-                warning('CA Certificate not found at ' . $certFilePath . '. Skipping copy.');
+            if (! file_exists($certFilePath)) {
+                warning('CA Certificate not found at '.$certFilePath.'. Skipping copy.');
 
                 return;
             }
@@ -36,7 +37,7 @@ trait CopiesCertificateAuthority
                 Path::join(base_path('vendor/nativephp/electron/resources/js/resources'), $certificateFileName)
             );
 
-            if (!$copied) {
+            if (! $copied) {
                 // It returned false, but doesn't give a reason why.
                 throw new \Exception('copy() failed for an unknown reason.');
             }

--- a/src/Traits/ExecuteCommand.php
+++ b/src/Traits/ExecuteCommand.php
@@ -20,13 +20,11 @@ trait ExecuteCommand
             'install' => [
                 'NATIVEPHP_PHP_BINARY_VERSION' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
                 'NATIVEPHP_PHP_BINARY_PATH' => base_path($this->phpBinaryPath()),
-                'NATIVEPHP_CERTIFICATE_FILE_PATH' => base_path($this->binaryPackageDirectory().'cacert.pem'),
             ],
             'serve' => [
                 'APP_PATH' => base_path(),
                 'NATIVEPHP_PHP_BINARY_VERSION' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
                 'NATIVEPHP_PHP_BINARY_PATH' => base_path($this->phpBinaryPath()),
-                'NATIVEPHP_CERTIFICATE_FILE_PATH' => base_path($this->binaryPackageDirectory().'cacert.pem'),
                 'NATIVE_PHP_SKIP_QUEUE' => $skip_queue,
                 'NATIVEPHP_BUILDING' => false,
             ],

--- a/tests/Unit/Traits/CopiesCertificateAuthorityTest.php
+++ b/tests/Unit/Traits/CopiesCertificateAuthorityTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Native\Electron\Tests\Unit\Traits;
+
+use Native\Electron\Traits\CopiesCertificateAuthority;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+it('can copy the default CA certificate from php-bin', function ($mock) {
+    // Set up
+    app()->setBasePath(realpath(__DIR__.'/../../../'));
+
+    /// Make directory temporarily
+    mkdir(base_path('vendor/nativephp/electron/resources/js/resources'), 0777, true);
+
+    // Test
+    expect(file_exists(base_path('vendor/nativephp/electron/resources/js/resources/cacert.pem')))->toBeFalse();
+
+    $mock->run();
+
+    expect(file_exists(base_path('vendor/nativephp/electron/resources/js/resources/cacert.pem')))->toBeTrue();
+
+    // Cleanup
+    // Delete the vendor/nativephp/electron directory, recursively including directories and then files
+    $files = new RecursiveIteratorIterator(
+        new RecursiveCallbackFilterIterator(
+            new RecursiveDirectoryIterator(base_path('vendor/nativephp/electron'), RecursiveDirectoryIterator::SKIP_DOTS),
+            fn ($current, $key, $iterator) => $current->isDir() || $current->isFile()
+        ),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($files as $file) {
+        if ($file->isDir()) {
+            rmdir($file->getRealPath());
+        } else {
+            unlink($file->getRealPath());
+        }
+    }
+
+    rmdir(base_path('vendor/nativephp/electron'));
+
+})->with([
+    // Empty class with the CopiesCertificateAuthority trait
+    new class
+    {
+        use CopiesCertificateAuthority;
+
+        public function run()
+        {
+            $this->copyCertificateAuthorityCertificate();
+        }
+    },
+]);

--- a/tests/Unit/Traits/CopiesCertificateAuthorityTest.php
+++ b/tests/Unit/Traits/CopiesCertificateAuthorityTest.php
@@ -11,7 +11,7 @@ it('can copy the default CA certificate from php-bin', function ($mock) {
     // Set up
     app()->setBasePath(realpath(__DIR__.'/../../../'));
 
-    /// Make directory temporarily
+    // / Make directory temporarily
     mkdir(base_path('vendor/nativephp/electron/resources/js/resources'), 0777, true);
 
     // Test


### PR DESCRIPTION
This pull request includes several changes to improve the handling of the CA certificate in the `Native\Electron` package. The most important changes involve the introduction of a new trait for copying the CA certificate and the removal of redundant code related to certificate handling.

### Introduction of `CopiesCertificateAuthority` trait:

* [`src/Traits/CopiesCertificateAuthority.php`](diffhunk://#diff-900fb9b99b5b364427987e22c8819c25cc1594ac36bcae1d320ecf8bd0cec119R1-R47): Added a new trait `CopiesCertificateAuthority` to encapsulate the logic for copying the CA certificate.

### Refactoring to use the new trait:

* [`src/Commands/BuildCommand.php`](diffhunk://#diff-aa5dd2724f30cebdd7795cf02ae6a572645fd33f0048b4cb27f37fdc985a46b0R10): Updated the `BuildCommand` class to use the new `CopiesCertificateAuthority` trait and removed the old certificate copying logic. [[1]](diffhunk://#diff-aa5dd2724f30cebdd7795cf02ae6a572645fd33f0048b4cb27f37fdc985a46b0R10) [[2]](diffhunk://#diff-aa5dd2724f30cebdd7795cf02ae6a572645fd33f0048b4cb27f37fdc985a46b0R26) [[3]](diffhunk://#diff-aa5dd2724f30cebdd7795cf02ae6a572645fd33f0048b4cb27f37fdc985a46b0L84-R86)
* [`src/Commands/DevelopCommand.php`](diffhunk://#diff-18b6b0817ca239241feded9a2bdbfd499c2ebab064594f7a2f422474039176eaR6): Updated the `DevelopCommand` class to use the new `CopiesCertificateAuthority` trait and added the certificate copying call. [[1]](diffhunk://#diff-18b6b0817ca239241feded9a2bdbfd499c2ebab064594f7a2f422474039176eaR6) [[2]](diffhunk://#diff-18b6b0817ca239241feded9a2bdbfd499c2ebab064594f7a2f422474039176eaL15-R19) [[3]](diffhunk://#diff-18b6b0817ca239241feded9a2bdbfd499c2ebab064594f7a2f422474039176eaR47-R48)

### Removal of redundant environment variables:

* [`src/Commands/BuildCommand.php`](diffhunk://#diff-aa5dd2724f30cebdd7795cf02ae6a572645fd33f0048b4cb27f37fdc985a46b0L124): Removed the `NATIVEPHP_CERTIFICATE_FILE_PATH` environment variable.
* [`src/Traits/ExecuteCommand.php`](diffhunk://#diff-b7f5dda687fcd9b255e5a0c6df9485aa936edfaa7d540b5bd85bad5bc59dd364L23-L29): Removed the `NATIVEPHP_CERTIFICATE_FILE_PATH` environment variable from the `executeCommand` method.

### Test for the new trait:

* [`tests/Unit/Traits/CopiesCertificateAuthorityTest.php`](diffhunk://#diff-8849e6b34aff2f8b355e6c2cc2595852452fcb34a90dfd183514106bfa990132R1-R55): Added a unit test to verify the functionality of the `CopiesCertificateAuthority` trait.

### Code cleanup:

* [`resources/js/php.js`](diffhunk://#diff-d374a31f5df4418652de60c931f43925923f63b005a28937570c05ae0be3d223L11): Removed the code related to copying the certificate file. [[1]](diffhunk://#diff-d374a31f5df4418652de60c931f43925923f63b005a28937570c05ae0be3d223L11) [[2]](diffhunk://#diff-d374a31f5df4418652de60c931f43925923f63b005a28937570c05ae0be3d223L101-L110)