### PR TITLE
Preserve permissions

### DIFF
--- a/src/Traits/CopiesToBuildDirectory.php
+++ b/src/Traits/CopiesToBuildDirectory.php
@@ -106,6 +106,14 @@ trait CopiesToBuildDirectory
             } catch (Throwable $e) {
                 warning('[WARNING] '.$e->getMessage());
             }
+
+            $perms = fileperms($item->getPathname());
+
+            if ($perms === false) {
+                continue;
+            }
+
+            chmod($target, $perms);
         }
 
         $this->keepRequiredDirectories();

--- a/tests/Unit/CopyToBuildDirectoryTest.php
+++ b/tests/Unit/CopyToBuildDirectoryTest.php
@@ -206,3 +206,15 @@ it('makes sure required folders are not empty', function () use ($buildPath, $co
 
     expect($required)->each->toBeFile();
 });
+
+it('preserves file permissions', function () use ($sourcePath, $buildPath, $command) {
+    createFiles("$sourcePath/file-under-test.txt");
+
+    chmod("$sourcePath/file-under-test.txt", octdec('0775'));
+
+    $originalPermissions = fileperms("$sourcePath/file-under-test.txt");
+
+    $command->copyToBuildDirectory();
+
+    expect(fileperms("$buildPath/file-under-test.txt"))->toBe($originalPermissions);
+});


### PR DESCRIPTION
`BuildCommand::class`'s `copy` resets all file perms to `100644` r+r for owner, read for everyone else.

Fixed this by just setting it back to original with `chmod`. Tests passing, added new assertions to ensure this works.

There are some intricacies around the 2nd param of `chmod`. It seems to be very user-unfriendly in terms of its behavior when dealing with various permission formats. Decimal values provided as `int` seem to be the way to go, which is also what the `fileperms` function returns by default.

Did a test build and my file permissions came out identical between the real project and the files copied to `resources/app`, I think we're good.