### PR TITLE
Add alert API routes and corresponding tests

### DIFF
--- a/resources/js/electron-plugin/src/server/api.ts
+++ b/resources/js/electron-plugin/src/server/api.ts
@@ -4,6 +4,7 @@ import getPort, {portNumbers} from "get-port";
 import middleware from "./api/middleware.js";
 
 import clipboardRoutes from "./api/clipboard.js";
+import alertRoutes from "./api/alert.js";
 import appRoutes from "./api/app.js";
 import screenRoutes from "./api/screen.js";
 import dialogRoutes from "./api/dialog.js";
@@ -40,6 +41,7 @@ async function startAPIServer(randomSecret: string): Promise<APIProcess> {
     httpServer.use(middleware(randomSecret));
     httpServer.use(bodyParser.json());
     httpServer.use("/api/clipboard", clipboardRoutes);
+    httpServer.use("/api/alert", alertRoutes);
     httpServer.use("/api/app", appRoutes);
     httpServer.use("/api/screen", screenRoutes);
     httpServer.use("/api/dialog", dialogRoutes);

--- a/resources/js/electron-plugin/src/server/api/alert.ts
+++ b/resources/js/electron-plugin/src/server/api/alert.ts
@@ -1,6 +1,7 @@
 import express from 'express'
 import { dialog } from 'electron'
 const router = express.Router();
+
 router.post('/message', (req, res) => {
     const { message, type, title, detail, buttons, defaultId, cancelId } = req.body;
     const result = dialog.showMessageBoxSync({

--- a/resources/js/electron-plugin/src/server/api/alert.ts
+++ b/resources/js/electron-plugin/src/server/api/alert.ts
@@ -1,0 +1,30 @@
+import express from 'express'
+import { dialog } from 'electron'
+const router = express.Router();
+router.post('/message', (req, res) => {
+    const { message, type, title, detail, buttons, defaultId, cancelId } = req.body;
+    const result = dialog.showMessageBoxSync({
+        message,
+        type,
+        title,
+        detail,
+        buttons,
+        defaultId,
+        cancelId
+    });
+    res.json({
+        result
+    });
+});
+
+router.post('/error', (req, res) => {
+    const { title, message } = req.body;
+
+    dialog.showErrorBox(title, message);
+
+    res.json({
+        result: true
+    });
+});
+
+export default router;

--- a/resources/js/electron-plugin/src/server/api/dialog.ts
+++ b/resources/js/electron-plugin/src/server/api/dialog.ts
@@ -60,29 +60,4 @@ router.post('/save', (req, res) => {
     })
 });
 
-router.post('/message', (req, res) => {
-    const {title, message, type, buttons} = req.body
-
-    const result = dialog.showMessageBoxSync({
-        title,
-        message,
-        type,
-        buttons
-    })
-
-    res.json({
-        result
-    })
-});
-
-router.post('/error', (req, res) => {
-    const {title, message} = req.body
-
-    dialog.showErrorBox(title, message)
-
-    res.json({
-        result: true
-    })
-});
-
 export default router;

--- a/resources/js/electron-plugin/tests/endpoints/alert.test.ts
+++ b/resources/js/electron-plugin/tests/endpoints/alert.test.ts
@@ -1,0 +1,56 @@
+import startAPIServer, {APIProcess} from "../../src/server/api";
+import axios from "axios";
+import electron from "electron";
+
+let apiServer: APIProcess;
+
+jest.mock('electron', () => ({
+    ...jest.requireActual('electron'),
+
+    dialog: {
+        showMessageBoxSync: jest.fn(() => 1),
+        showErrorBox: jest.fn(),
+    }
+}));
+
+describe('Alert test', () => {
+  beforeEach(async () => {
+    apiServer = await startAPIServer('randomSecret')
+
+    axios.defaults.baseURL = `http://localhost:${apiServer.port}/api`;
+    axios.defaults.headers.common['x-nativephp-secret'] = 'randomSecret';
+  })
+
+  afterEach(done => {
+    apiServer.server.close(done);
+  });
+
+  it('can open a alert', async () => {
+    const options = {
+      message: 'Do you really want to delete this?',
+      type: 'info',
+      title: 'Are you sure',
+      detail: 'This action cannot be undone',
+      buttons: ['Delete', 'Cancel'],
+      defaultId: 0,
+      cancelId: 1
+    }
+
+    const response = await axios.post('/alert/message', options);
+
+    expect(electron.dialog.showMessageBoxSync).toHaveBeenCalledWith(options);
+    expect(response.data.result).toEqual(1);
+  });
+
+  it('can open an error alert', async () => {
+    const options = {
+      title: 'Error Dialog',
+      message: 'Uh oh!',
+    }
+
+    const response = await axios.post('/alert/error', options);
+
+    expect(electron.dialog.showErrorBox).toHaveBeenCalledWith(options.title, options.message);
+    expect(response.data.result).toEqual(true);
+  });
+});

--- a/resources/js/electron-plugin/tests/endpoints/dialog.test.ts
+++ b/resources/js/electron-plugin/tests/endpoints/dialog.test.ts
@@ -66,30 +66,4 @@ describe('Dialog test', () => {
     expect(response.data.result).toEqual(['save dialog result']);
   });
 
-  it('can open a message dialog', async () => {
-    const options = {
-      title: 'Open Dialog',
-      message: 'Select an image',
-      type: 'info',
-      buttons: ['OK', 'Cancel']
-    }
-
-    const response = await axios.post('/dialog/message', options);
-
-    expect(electron.dialog.showMessageBoxSync).toHaveBeenCalledWith(options);
-    expect(response.data.result).toEqual(1);
-  });
-
-  it('can open an error dialog', async () => {
-    const options = {
-      title: 'Error Dialog',
-      message: 'Uh oh!',
-    }
-
-    const response = await axios.post('/dialog/error', options);
-
-    expect(electron.dialog.showErrorBox).toHaveBeenCalledWith(options.title, options.message);
-    expect(response.data.result).toEqual(true);
-  });
-
 });


### PR DESCRIPTION
I saw that there were remnants of the Electron-MessageBox Api. I removed the remnants from the dialog and created a new class “Alert”.

PR: NativePHP/laravel
https://github.com/NativePHP/laravel/pull/523