### PR TITLE
add 'all' option to `publish` command

### DIFF
--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -3,9 +3,9 @@
 namespace Native\Electron\Commands;
 
 use Illuminate\Console\Command;
-use Native\Electron\Traits\OsAndArch;
 use Illuminate\Support\Facades\Artisan;
 use Native\Electron\Traits\LocatesPhpBinary;
+use Native\Electron\Traits\OsAndArch;
 
 class PublishCommand extends Command
 {

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -3,9 +3,9 @@
 namespace Native\Electron\Commands;
 
 use Illuminate\Console\Command;
+use Native\Electron\Traits\OsAndArch;
 use Illuminate\Support\Facades\Artisan;
 use Native\Electron\Traits\LocatesPhpBinary;
-use Native\Electron\Traits\OsAndArch;
 
 class PublishCommand extends Command
 {
@@ -13,10 +13,10 @@ class PublishCommand extends Command
     use OsAndArch;
 
     protected $signature = 'native:publish
-        {os? : The operating system to build for (linux, mac, win)}
+        {os? : The operating system to build for (all, linux, mac, win)}
         {arch? : The Processor Architecture to build for (x64, x86, arm64)}';
 
-    protected array $availableOs = ['win', 'linux', 'mac'];
+    protected array $availableOs = ['win', 'linux', 'mac', 'all'];
 
     public function handle(): void
     {
@@ -24,7 +24,11 @@ class PublishCommand extends Command
 
         $os = $this->selectOs($this->argument('os'));
 
-        $arch = $this->selectArchitectureForOs($os, $this->argument('arch'));
+        $arch = null;
+
+        if ($os != 'all') {
+            $arch = $this->selectArchitectureForOs($os, $this->argument('arch'));
+        }
 
         Artisan::call('native:build', ['os' => $os, 'arch' => $arch, '--publish' => true], $this->output);
     }


### PR DESCRIPTION
This PR adds the `all` option to the `publish` command. Making it symmetrical to the `build` command