### PR TITLE
Skip chmod on Windows to avoid unnecessary permission changes

### DIFF
--- a/src/Traits/CopiesToBuildDirectory.php
+++ b/src/Traits/CopiesToBuildDirectory.php
@@ -118,7 +118,9 @@ trait CopiesToBuildDirectory
                 continue;
             }
 
-            chmod($target, $perms);
+            if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+                chmod($target, $perms);
+            }
         }
 
         $this->keepRequiredDirectories();


### PR DESCRIPTION
This pull request prevents chmod from running on Windows, as it is not required and can be skipped safely.

Changes made:
Added a condition to check the operating system (PHP_OS).

chmod($target, $perms); now only executes on non-Windows systems.

Reason for the change:
Since Windows does not support Unix-style file permissions, calling chmod is unnecessary and has no effect. This update ensures compatibility and avoids redundant function calls on Windows environments.

Testing & Impact:
This change does not affect Linux/macOS functionality.

It improves Windows compatibility by preventing unnecessary operations.