### PR TITLE
Fix menubar tray can be nullable

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/menuBar.js
+++ b/resources/js/electron-plugin/dist/server/api/menuBar.js
@@ -8,24 +8,28 @@ import { fileURLToPath } from 'url';
 import { enable } from "@electron/remote/main/index.js";
 const router = express.Router();
 router.post("/label", (req, res) => {
+    var _a;
     res.sendStatus(200);
     const { label } = req.body;
-    state.tray.setTitle(label);
+    (_a = state.tray) === null || _a === void 0 ? void 0 : _a.setTitle(label);
 });
 router.post("/tooltip", (req, res) => {
+    var _a;
     res.sendStatus(200);
     const { tooltip } = req.body;
-    state.tray.setToolTip(tooltip);
+    (_a = state.tray) === null || _a === void 0 ? void 0 : _a.setToolTip(tooltip);
 });
 router.post("/icon", (req, res) => {
+    var _a;
     res.sendStatus(200);
     const { icon } = req.body;
-    state.tray.setImage(icon);
+    (_a = state.tray) === null || _a === void 0 ? void 0 : _a.setImage(icon);
 });
 router.post("/context-menu", (req, res) => {
+    var _a;
     res.sendStatus(200);
     const { contextMenu } = req.body;
-    state.tray.setContextMenu(buildMenu(contextMenu));
+    (_a = state.tray) === null || _a === void 0 ? void 0 : _a.setContextMenu(buildMenu(contextMenu));
 });
 router.post("/show", (req, res) => {
     res.sendStatus(200);

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -14,7 +14,7 @@ router.post("/label", (req, res) => {
 
     const { label } = req.body;
 
-    state.tray.setTitle(label);
+    state.tray?.setTitle(label);
 });
 
 router.post("/tooltip", (req, res) => {
@@ -22,7 +22,7 @@ router.post("/tooltip", (req, res) => {
 
     const { tooltip } = req.body;
 
-    state.tray.setToolTip(tooltip);
+    state.tray?.setToolTip(tooltip);
 });
 
 router.post("/icon", (req, res) => {
@@ -30,7 +30,7 @@ router.post("/icon", (req, res) => {
 
     const { icon } = req.body;
 
-    state.tray.setImage(icon);
+    state.tray?.setImage(icon);
 });
 
 router.post("/context-menu", (req, res) => {
@@ -38,7 +38,7 @@ router.post("/context-menu", (req, res) => {
 
     const { contextMenu } = req.body;
 
-    state.tray.setContextMenu(buildMenu(contextMenu));
+    state.tray?.setContextMenu(buildMenu(contextMenu));
 });
 
 router.post("/show", (req, res) => {


### PR DESCRIPTION
The menubar tray can be null with window content

No tray is set in the options:
<img width="754" alt="Bildschirmfoto 2025-03-31 um 12 09 01" src="https://github.com/user-attachments/assets/f1678fb0-42f4-4c3f-a61d-5c9666dc6b46" />

Null for tray is possible:
<img width="484" alt="Bildschirmfoto 2025-03-31 um 12 07 33" src="https://github.com/user-attachments/assets/8987eb7a-d0b2-4ade-b30d-03dde0a4cd63" />


Noticed by error message in the console:
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/c738d957-b0d7-4061-9bb2-feec520476c2" />
