### PR TITLE
Pin php-bin to v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "laravel/prompts": "^0.1.1|^0.2|^0.3",
         "nativephp/laravel": "^1.0",
-        "nativephp/php-bin": "^0.6",
+        "nativephp/php-bin": "^1.0",
         "spatie/laravel-package-tools": "^1.16.4",
         "symfony/filesystem": "^6.4|^7.2",
         "ext-zip": "*"


### PR DESCRIPTION
This pull request includes a small change to the `composer.json` file. The change updates the version constraint for the `nativephp/php-bin` package to `^1.0`.