### PR TITLE
fix: zephpyr.com bundle on Windows

### DIFF
--- a/src/Commands/BundleCommand.php
+++ b/src/Commands/BundleCommand.php
@@ -283,7 +283,10 @@ class BundleCommand extends Command
                 continue;
             }
 
-            $zip->addFile($file->getRealPath(), str($path)->finish(DIRECTORY_SEPARATOR).$file->getRelativePathname());
+            $zipPath = str($path)->finish('/').$file->getRelativePathname();
+            $zipPath = str_replace('\\', '/', $zipPath);
+
+            $zip->addFile($file->getRealPath(), $zipPath);
         }
     }
 


### PR DESCRIPTION
The ZIP extension in PHP expects forward slashes (/) as directory separators inside archives, regardless of the operating system.