### PR TITLE
Ensure notarization env vars are available even if config is cached

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -146,6 +146,10 @@ class BuildCommand extends Command
                 'NATIVEPHP_APP_AUTHOR' => config('nativephp.author'),
                 'NATIVEPHP_UPDATER_CONFIG' => json_encode(Updater::builderOptions()),
                 'NATIVEPHP_DEEPLINK_SCHEME' => config('nativephp.deeplink_scheme'),
+                // Notarization
+                'NATIVEPHP_APPLE_ID' => config('nativephp-internal.notarization.apple_id'),
+                'NATIVEPHP_APPLE_ID_PASS' => config('nativephp-internal.notarization.apple_id_pass'),
+                'NATIVEPHP_APPLE_TEAM_ID' => config('nativephp-internal.notarization.apple_team_id'),
             ],
             Updater::environmentVariables(),
         );


### PR DESCRIPTION
This pull request includes a change to the `src/Commands/BuildCommand.php` file. The change adds new environment variables related to notarization to the `getEnvironmentVariables` method.

Notarization-related changes:

* [`src/Commands/BuildCommand.php`](diffhunk://#diff-aa5dd2724f30cebdd7795cf02ae6a572645fd33f0048b4cb27f37fdc985a46b0R149-R152): Added `NATIVEPHP_APPLE_ID`, `NATIVEPHP_APPLE_ID_PASS`, and `NATIVEPHP_APPLE_TEAM_ID` environment variables to support notarization.