### PR TITLE
fix: fileperms(): stat failed for public/storage

### DIFF
--- a/src/Traits/CopiesToBuildDirectory.php
+++ b/src/Traits/CopiesToBuildDirectory.php
@@ -113,7 +113,7 @@ trait CopiesToBuildDirectory
             }
 
             if (PHP_OS_FAMILY !== 'Windows') {
-                $perms = fileperms($item->getPathname());
+                $perms = @fileperms($item->getPathname());
                 if ($perms !== false) {
                     chmod($target, $perms);
                 }


### PR DESCRIPTION
Fix the following error:

`fileperms(): stat failed for /Users/eserdeniz/Projects/tailscale-notifier/public/storage`