### PR TITLE
Remove L10 from test matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,11 +18,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         php: [ 8.4, 8.3 ]
-        laravel: [ '10.*', '11.*', '12.*' ]
+        laravel: [ '11.*', '12.*' ]
         stability: [ prefer-lowest, prefer-stable ]
-        exclude:
-          - laravel: 10.*
-            php: 8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to update the test matrix for Laravel versions.

Changes in `.github/workflows/run-tests.yml`:

* Removed support for Laravel 10.x from the test matrix.
* Removed the exclusion rule for Laravel 10.x and PHP 8.4, as Laravel 10.x is no longer included in the matrix.