### PR TITLE
fix: custom PHP binary package not pruned on build

### DIFF
--- a/src/Commands/BundleCommand.php
+++ b/src/Commands/BundleCommand.php
@@ -14,6 +14,7 @@ use Native\Electron\Traits\CopiesToBuildDirectory;
 use Native\Electron\Traits\HandlesZephpyr;
 use Native\Electron\Traits\HasPreAndPostProcessing;
 use Native\Electron\Traits\InstallsAppIcon;
+use Native\Electron\Traits\LocatesPhpBinary;
 use Native\Electron\Traits\PrunesVendorDirectory;
 use Native\Electron\Traits\SetsAppName;
 use Symfony\Component\Finder\Finder;
@@ -28,6 +29,7 @@ class BundleCommand extends Command
     use HandlesZephpyr;
     use HasPreAndPostProcessing;
     use InstallsAppIcon;
+    use LocatesPhpBinary;
     use PrunesVendorDirectory;
     use SetsAppName;
 

--- a/src/Traits/PrunesVendorDirectory.php
+++ b/src/Traits/PrunesVendorDirectory.php
@@ -29,7 +29,7 @@ trait PrunesVendorDirectory
 
         // Remove custom php binary package directory
         $binaryPackageDirectory = $this->binaryPackageDirectory();
-        if (! empty($binaryPackageDirectory)) {
+        if (! empty($binaryPackageDirectory) && $filesystem->exists($this->buildPath($binaryPackageDirectory))) {
             $filesystem->remove($this->buildPath($binaryPackageDirectory));
         }
     }

--- a/src/Traits/PrunesVendorDirectory.php
+++ b/src/Traits/PrunesVendorDirectory.php
@@ -16,6 +16,7 @@ trait PrunesVendorDirectory
     protected function pruneVendorDirectory()
     {
         Process::path($this->buildPath())
+            ->timeout(300)
             ->run('composer install --no-dev', function (string $type, string $output) {
                 echo $output;
             });
@@ -25,5 +26,11 @@ trait PrunesVendorDirectory
             $this->buildPath('/vendor/bin'),
             $this->buildPath('/vendor/nativephp/php-bin'),
         ]);
+
+        // Remove custom php binary package directory
+        $binaryPackageDirectory = $this->binaryPackageDirectory();
+        if (! empty($binaryPackageDirectory)) {
+            $filesystem->remove($this->buildPath($binaryPackageDirectory));
+        }
     }
 }


### PR DESCRIPTION
This bug bundled every PHP version when custom PHP binaries were used, resulting in a large Electron file and blocking the notarization process.

- Increased timeout for composer install  
- Clean up custom PHP binary package directory
