### PR TITLE
fix: Please provide a valid cache path.

### DIFF
--- a/resources/js/electron-plugin/dist/server/php.js
+++ b/resources/js/electron-plugin/dist/server/php.js
@@ -24,6 +24,10 @@ const bootstrapCache = join(app.getPath('userData'), 'bootstrap', 'cache');
 const argumentEnv = getArgumentEnv();
 const appPath = getAppPath();
 mkdirpSync(bootstrapCache);
+mkdirpSync(join(storagePath, 'logs'));
+mkdirpSync(join(storagePath, 'framework', 'cache'));
+mkdirpSync(join(storagePath, 'framework', 'sessions'));
+mkdirpSync(join(storagePath, 'framework', 'views'));
 function runningSecureBuild() {
     return existsSync(join(appPath, 'build', '__nativephp_app_bundle'))
         && process.env.NODE_ENV !== 'development';

--- a/resources/js/electron-plugin/dist/server/php.js
+++ b/resources/js/electron-plugin/dist/server/php.js
@@ -28,6 +28,7 @@ mkdirpSync(join(storagePath, 'logs'));
 mkdirpSync(join(storagePath, 'framework', 'cache'));
 mkdirpSync(join(storagePath, 'framework', 'sessions'));
 mkdirpSync(join(storagePath, 'framework', 'views'));
+mkdirpSync(join(storagePath, 'framework', 'testing'));
 function runningSecureBuild() {
     return existsSync(join(appPath, 'build', '__nativephp_app_bundle'))
         && process.env.NODE_ENV !== 'development';

--- a/resources/js/electron-plugin/src/server/php.ts
+++ b/resources/js/electron-plugin/src/server/php.ts
@@ -21,6 +21,11 @@ const argumentEnv = getArgumentEnv();
 const appPath = getAppPath();
 
 mkdirpSync(bootstrapCache);
+mkdirpSync(join(storagePath, 'logs'));
+mkdirpSync(join(storagePath, 'framework', 'cache'));
+mkdirpSync(join(storagePath, 'framework', 'sessions'));
+mkdirpSync(join(storagePath, 'framework', 'views'));
+mkdirpSync(join(storagePath, 'framework', 'testing'));
 
 function runningSecureBuild() {
     return existsSync(join(appPath, 'build', '__nativephp_app_bundle'))


### PR DESCRIPTION
With the added environment variable in this [commit](https://github.com/NativePHP/electron/commit/a2f98889a18d00a5b9e9342f06d51b6c6bf09db6#diff-edf9ec79371541b54bd5647c93b0ba374e50d9986b59c2acd57f410d70d8bb8bR140), we definitely need to create those directories ourselves.

**Why did it work before?**  
Because previously, the app was sometimes writing to itself.  
With bundling, we need every write operation to be outside the app.  
This is why we introduced the usage of `LARAVEL_STORAGE_PATH`.