### PR TITLE
fix: set LOG_LEVEL to "warning" in production

### DIFF
--- a/src/Traits/CleansEnvFile.php
+++ b/src/Traits/CleansEnvFile.php
@@ -17,6 +17,7 @@ trait CleansEnvFile
         'LOG_CHANNEL',
         'LOG_STACK',
         'LOG_DAILY_DAYS',
+        'LOG_LEVEL',
     ];
 
     public function cleanEnvFile(): void
@@ -38,6 +39,7 @@ trait CleansEnvFile
             ->push('LOG_CHANNEL=stack')
             ->push('LOG_STACK=daily')
             ->push('LOG_DAILY_DAYS=3')
+            ->push('LOG_LEVEL=warning')
             ->join("\n");
 
         file_put_contents($envFile, $contents);


### PR DESCRIPTION
The goal is to not have "info" logs of nativePHP/Electron javascript events.