### PR TITLE
fix: handle power monitor events to manage scheduler lifecycle

### DIFF
--- a/resources/js/electron-plugin/dist/index.js
+++ b/resources/js/electron-plugin/dist/index.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { app, session } from "electron";
+import { app, session, powerMonitor } from "electron";
 import { initialize } from "@electron/remote/main/index.js";
 import state from "./server/state.js";
 import { electronApp, optimizer } from "@electron-toolkit/utils";
@@ -80,6 +80,13 @@ class NativePHP {
             state.phpIni = yield this.loadPhpIni();
             yield this.startPhpApp();
             this.startScheduler();
+            powerMonitor.on("suspend", () => {
+                this.stopScheduler();
+            });
+            powerMonitor.on("resume", () => {
+                this.stopScheduler();
+                this.startScheduler();
+            });
             const filter = {
                 urls: [`http://127.0.0.1:${state.phpPort}/*`]
             };
@@ -180,6 +187,12 @@ class NativePHP {
         return __awaiter(this, void 0, void 0, function* () {
             this.processes.push(yield startPhpApp());
         });
+    }
+    stopScheduler() {
+        if (this.schedulerInterval) {
+            clearInterval(this.schedulerInterval);
+            this.schedulerInterval = null;
+        }
     }
     startScheduler() {
         const now = new Date();


### PR DESCRIPTION
Fixes: https://github.com/NativePHP/laravel/issues/542

Getting a Bad File Descriptor Error after the app is resumed from sleep for every scheduler run.

Laravel scheduler improvement:
* Imported `powerMonitor` module from `electron`
* Added event listeners for `suspend` and `resume` events to manage scheduler state
* Introduced a `stopScheduler` method to clear and reset the scheduler interval