### PR TITLE
fix: App::version() not returning the correct version

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -13,8 +13,8 @@ use Native\Electron\Traits\HasPreAndPostProcessing;
 use Native\Electron\Traits\InstallsAppIcon;
 use Native\Electron\Traits\LocatesPhpBinary;
 use Native\Electron\Traits\OsAndArch;
-use Native\Electron\Traits\PrunesVendorDirectory;
 use Native\Electron\Traits\PatchesPackagesJson;
+use Native\Electron\Traits\PrunesVendorDirectory;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
 use function Laravel\Prompts\intro;
@@ -28,8 +28,8 @@ class BuildCommand extends Command
     use InstallsAppIcon;
     use LocatesPhpBinary;
     use OsAndArch;
-    use PrunesVendorDirectory;
     use PatchesPackagesJson;
+    use PrunesVendorDirectory;
 
     protected $signature = 'native:build
         {os? : The operating system to build for (all, linux, mac, win)}

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -14,7 +14,7 @@ use Native\Electron\Traits\InstallsAppIcon;
 use Native\Electron\Traits\LocatesPhpBinary;
 use Native\Electron\Traits\OsAndArch;
 use Native\Electron\Traits\PrunesVendorDirectory;
-use Native\Electron\Traits\SetsAppName;
+use Native\Electron\Traits\PatchesPackagesJson;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
 use function Laravel\Prompts\intro;
@@ -29,7 +29,7 @@ class BuildCommand extends Command
     use LocatesPhpBinary;
     use OsAndArch;
     use PrunesVendorDirectory;
-    use SetsAppName;
+    use PatchesPackagesJson;
 
     protected $signature = 'native:build
         {os? : The operating system to build for (all, linux, mac, win)}
@@ -78,7 +78,7 @@ class BuildCommand extends Command
 
     private function buildBundle(): void
     {
-        $this->setAppName();
+        $this->setAppNameAndVersion();
 
         $this->updateElectronDependencies();
 
@@ -101,7 +101,7 @@ class BuildCommand extends Command
     {
         $this->preProcess();
 
-        $this->setAppName();
+        $this->setAppNameAndVersion();
 
         $this->updateElectronDependencies();
 

--- a/src/Commands/BundleCommand.php
+++ b/src/Commands/BundleCommand.php
@@ -15,8 +15,8 @@ use Native\Electron\Traits\HandlesZephpyr;
 use Native\Electron\Traits\HasPreAndPostProcessing;
 use Native\Electron\Traits\InstallsAppIcon;
 use Native\Electron\Traits\LocatesPhpBinary;
-use Native\Electron\Traits\PrunesVendorDirectory;
 use Native\Electron\Traits\PatchesPackagesJson;
+use Native\Electron\Traits\PrunesVendorDirectory;
 use Symfony\Component\Finder\Finder;
 use ZipArchive;
 
@@ -30,8 +30,8 @@ class BundleCommand extends Command
     use HasPreAndPostProcessing;
     use InstallsAppIcon;
     use LocatesPhpBinary;
-    use PrunesVendorDirectory;
     use PatchesPackagesJson;
+    use PrunesVendorDirectory;
 
     protected $signature = 'native:bundle {--fetch} {--clear} {--without-cleanup}';
 

--- a/src/Commands/BundleCommand.php
+++ b/src/Commands/BundleCommand.php
@@ -16,7 +16,7 @@ use Native\Electron\Traits\HasPreAndPostProcessing;
 use Native\Electron\Traits\InstallsAppIcon;
 use Native\Electron\Traits\LocatesPhpBinary;
 use Native\Electron\Traits\PrunesVendorDirectory;
-use Native\Electron\Traits\SetsAppName;
+use Native\Electron\Traits\PatchesPackagesJson;
 use Symfony\Component\Finder\Finder;
 use ZipArchive;
 
@@ -31,7 +31,7 @@ class BundleCommand extends Command
     use InstallsAppIcon;
     use LocatesPhpBinary;
     use PrunesVendorDirectory;
-    use SetsAppName;
+    use PatchesPackagesJson;
 
     protected $signature = 'native:bundle {--fetch} {--clear} {--without-cleanup}';
 
@@ -87,7 +87,7 @@ class BundleCommand extends Command
 
         $this->preProcess();
 
-        $this->setAppName();
+        $this->setAppNameAndVersion();
         intro('Copying App to build directory...');
 
         // We update composer.json later,

--- a/src/Commands/DevelopCommand.php
+++ b/src/Commands/DevelopCommand.php
@@ -7,7 +7,7 @@ use Native\Electron\Traits\CopiesCertificateAuthority;
 use Native\Electron\Traits\Developer;
 use Native\Electron\Traits\Installer;
 use Native\Electron\Traits\InstallsAppIcon;
-use Native\Electron\Traits\SetsAppName;
+use Native\Electron\Traits\PatchesPackagesJson;
 
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\note;
@@ -18,7 +18,7 @@ class DevelopCommand extends Command
     use Developer;
     use Installer;
     use InstallsAppIcon;
-    use SetsAppName;
+    use PatchesPackagesJson;
 
     protected $signature = 'native:serve {--no-queue} {--D|no-dependencies} {--installer=npm}';
 
@@ -42,7 +42,7 @@ class DevelopCommand extends Command
             $this->patchPlist();
         }
 
-        $this->setAppName(developmentMode: true);
+        $this->setAppNameAndVersion(developmentMode: true);
 
         $this->installIcon();
 

--- a/src/Commands/ResetCommand.php
+++ b/src/Commands/ResetCommand.php
@@ -3,14 +3,14 @@
 namespace Native\Electron\Commands;
 
 use Illuminate\Console\Command;
-use Native\Electron\Traits\SetsAppName;
+use Native\Electron\Traits\PatchesPackagesJson;
 use Symfony\Component\Filesystem\Filesystem;
 
 use function Laravel\Prompts\intro;
 
 class ResetCommand extends Command
 {
-    use SetsAppName;
+    use PatchesPackagesJson;
 
     protected $signature = 'native:reset {--with-app-data : Clear the app data as well}';
 
@@ -49,7 +49,7 @@ class ResetCommand extends Command
         if ($this->option('with-app-data')) {
 
             foreach ([true, false] as $developmentMode) {
-                $appName = $this->setAppName($developmentMode);
+                $appName = $this->setAppNameAndVersion($developmentMode);
 
                 // Eh, just in case, I don't want to delete all user data by accident.
                 if (! empty($appName)) {

--- a/src/Traits/PatchesPackagesJson.php
+++ b/src/Traits/PatchesPackagesJson.php
@@ -2,9 +2,9 @@
 
 namespace Native\Electron\Traits;
 
-trait SetsAppName
+trait PatchesPackagesJson
 {
-    protected function setAppName($developmentMode = false): string
+    protected function setAppNameAndVersion($developmentMode = false): string
     {
         $packageJsonPath = __DIR__.'/../../resources/js/package.json';
         $packageJson = json_decode(file_get_contents($packageJsonPath), true);
@@ -21,6 +21,7 @@ trait SetsAppName
         }
 
         $packageJson['name'] = $name;
+        $packageJson['version'] = config('nativephp.version');
 
         file_put_contents($packageJsonPath, json_encode($packageJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 


### PR DESCRIPTION
From electron code comment:
> getVersion(): string; The version of the loaded application. If no version is found in the application's package.json file, the version of the current bundle or executable is returned.

