### PR TITLE
Add support for `showOnAllWorkspaces` parameter in menuBar

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/menuBar.js
+++ b/resources/js/electron-plugin/dist/server/api/menuBar.js
@@ -47,7 +47,7 @@ router.post("/create", (req, res) => {
         state.activeMenuBar.tray.destroy();
         shouldSendCreatedEvent = false;
     }
-    const { width, height, url, label, alwaysOnTop, vibrancy, backgroundColor, transparency, icon, showDockIcon, onlyShowContextMenu, windowPosition, contextMenu, tooltip, resizable, event, } = req.body;
+    const { width, height, url, label, alwaysOnTop, vibrancy, backgroundColor, transparency, icon, showDockIcon, onlyShowContextMenu, windowPosition, showOnAllWorkspaces, contextMenu, tooltip, resizable, event, } = req.body;
     if (onlyShowContextMenu) {
         const tray = new Tray(icon || state.icon.replace("icon.png", "IconTemplate.png"));
         tray.setContextMenu(buildMenu(contextMenu));
@@ -66,7 +66,7 @@ router.post("/create", (req, res) => {
             tooltip,
             index: url,
             showDockIcon,
-            showOnAllWorkspaces: false,
+            showOnAllWorkspaces: showOnAllWorkspaces !== null && showOnAllWorkspaces !== void 0 ? showOnAllWorkspaces : false,
             windowPosition: windowPosition !== null && windowPosition !== void 0 ? windowPosition : "trayCenter",
             activateWithApp: false,
             browserWindow: {

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -84,6 +84,7 @@ router.post("/create", (req, res) => {
         showDockIcon,
         onlyShowContextMenu,
         windowPosition,
+        showOnAllWorkspaces,
         contextMenu,
         tooltip,
         resizable,
@@ -117,7 +118,7 @@ router.post("/create", (req, res) => {
             tooltip,
             index: url,
             showDockIcon,
-            showOnAllWorkspaces: false,
+            showOnAllWorkspaces: showOnAllWorkspaces ?? false,
             windowPosition: windowPosition ?? "trayCenter",
             activateWithApp: false,
             browserWindow: {


### PR DESCRIPTION
Integrate the `showOnAllWorkspaces` parameter into menuBar API logic, allowing greater control over workspace visibility. Defaults are applied to ensure backward compatibility when the parameter is not provided.

PR:
NativePHP/laravel: https://github.com/NativePHP/laravel/pull/568