### PR TITLE
Add endpoint to relaunch the app

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/app.js
+++ b/resources/js/electron-plugin/dist/server/api/app.js
@@ -6,9 +6,7 @@ router.post('/quit', (req, res) => {
     res.sendStatus(200);
 });
 router.post('/relaunch', (req, res) => {
-    app.relaunch({
-        args: process.argv.slice(1).concat(['--relaunch']),
-    });
+    app.relaunch();
     app.quit();
 });
 router.post('/show', (req, res) => {

--- a/resources/js/electron-plugin/dist/server/api/app.js
+++ b/resources/js/electron-plugin/dist/server/api/app.js
@@ -5,6 +5,12 @@ router.post('/quit', (req, res) => {
     app.quit();
     res.sendStatus(200);
 });
+router.post('/relaunch', (req, res) => {
+    app.relaunch({
+        args: process.argv.slice(1).concat(['--relaunch']),
+    });
+    app.quit();
+});
 router.post('/show', (req, res) => {
     app.show();
     res.sendStatus(200);

--- a/resources/js/electron-plugin/src/server/api/app.ts
+++ b/resources/js/electron-plugin/src/server/api/app.ts
@@ -8,9 +8,7 @@ router.post('/quit', (req, res) => {
 });
 
 router.post('/relaunch', (req, res) => {
-    app.relaunch({
-        args: process.argv.slice(1).concat(['--relaunch']),
-    })
+    app.relaunch()
     app.quit()
 });
 

--- a/resources/js/electron-plugin/src/server/api/app.ts
+++ b/resources/js/electron-plugin/src/server/api/app.ts
@@ -7,6 +7,13 @@ router.post('/quit', (req, res) => {
     res.sendStatus(200);
 });
 
+router.post('/relaunch', (req, res) => {
+    app.relaunch({
+        args: process.argv.slice(1).concat(['--relaunch']),
+    })
+    app.quit()
+});
+
 router.post('/show', (req, res) => {
     app.show()
     res.sendStatus(200);


### PR DESCRIPTION
Added a new `/relaunch` POST endpoint to restart the app with relaunch options. It uses `app.relaunch` with the current arguments and then quits the app. This ensures a seamless restart process for the application.

PR:
NativePHP/laravel: https://github.com/NativePHP/laravel/pull/569