### PR TITLE
Update package.json patch logic to include new fields

### DIFF
--- a/src/Traits/PatchesPackagesJson.php
+++ b/src/Traits/PatchesPackagesJson.php
@@ -22,6 +22,9 @@ trait PatchesPackagesJson
 
         $packageJson['name'] = $name;
         $packageJson['version'] = config('nativephp.version');
+        $packageJson['description'] = config('nativephp.description');
+        $packageJson['author'] = config('nativephp.author');
+        $packageJson['homepage'] = config('nativephp.website');
 
         file_put_contents($packageJsonPath, json_encode($packageJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 


### PR DESCRIPTION
Added fields `description`, `author`, and `homepage` to the package.json patching logic, sourced from configuration values. This ensures more comprehensive metadata is included when generating or updating the package.json file.

PR:
NativePHP/laravel: https://github.com/NativePHP/laravel/pull/571