### PR TITLE
Adjust window dimensions based on the `resizable` property.

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/window.js
+++ b/resources/js/electron-plugin/dist/server/api/window.js
@@ -163,7 +163,11 @@ router.post('/open', (req, res) => {
             defaultWidth: parseInt(width),
         });
     }
-    const window = new BrowserWindow(Object.assign(Object.assign({ width: (windowState === null || windowState === void 0 ? void 0 : windowState.width) || parseInt(width), height: (windowState === null || windowState === void 0 ? void 0 : windowState.height) || parseInt(height), frame: frame !== undefined ? frame : true, x: (windowState === null || windowState === void 0 ? void 0 : windowState.x) || x, y: (windowState === null || windowState === void 0 ? void 0 : windowState.y) || y, minWidth: minWidth, minHeight: minHeight, maxWidth: maxWidth, maxHeight: maxHeight, show: false, title,
+    const window = new BrowserWindow(Object.assign(Object.assign({ width: resizable
+            ? (windowState === null || windowState === void 0 ? void 0 : windowState.width) || parseInt(width)
+            : parseInt(width), height: resizable
+            ? (windowState === null || windowState === void 0 ? void 0 : windowState.height) || parseInt(height)
+            : parseInt(height), frame: frame !== undefined ? frame : true, x: (windowState === null || windowState === void 0 ? void 0 : windowState.x) || x, y: (windowState === null || windowState === void 0 ? void 0 : windowState.y) || y, minWidth: minWidth, minHeight: minHeight, maxWidth: maxWidth, maxHeight: maxHeight, show: false, title,
         backgroundColor, transparent: transparency, alwaysOnTop,
         resizable,
         movable,

--- a/resources/js/electron-plugin/src/server/api/window.ts
+++ b/resources/js/electron-plugin/src/server/api/window.ts
@@ -255,8 +255,12 @@ router.post('/open', (req, res) => {
     }
 
     const window = new BrowserWindow({
-        width: windowState?.width || parseInt(width),
-        height: windowState?.height || parseInt(height),
+        width: resizable
+            ? windowState?.width || parseInt(width)
+            : parseInt(width),
+        height: resizable
+            ? windowState?.height || parseInt(height)
+            : parseInt(height),
         frame: frame !== undefined ? frame : true,
         x: windowState?.x || x,
         y: windowState?.y || y,


### PR DESCRIPTION
Updated the logic to set window width and height to ignore stored window state when `resizable` is false. This ensures consistent behavior for fixed-size windows regardless of previous state data.