### PR TITLE
Add support for additional app icon formats

### DIFF
--- a/src/Traits/InstallsAppIcon.php
+++ b/src/Traits/InstallsAppIcon.php
@@ -8,6 +8,10 @@ trait InstallsAppIcon
     {
         @copy(public_path('icon.png'), __DIR__.'/../../resources/js/build/icon.png');
         @copy(public_path('icon.png'), __DIR__.'/../../resources/js/resources/icon.png');
+        @copy(public_path('icon.ico'), __DIR__.'/../../resources/js/build/icon.ico');
+        @copy(public_path('icon.ico'), __DIR__.'/../../resources/js/resources/icon.ico');
+        @copy(public_path('icon.icns'), __DIR__.'/../../resources/js/build/icon.icns');
+        @copy(public_path('icon.icns'), __DIR__.'/../../resources/js/resources/icon.icns');
         @copy(public_path('IconTemplate.png'), __DIR__.'/../../resources/js/resources/IconTemplate.png');
         @copy(public_path('IconTemplate@2x.png'), __DIR__.'/../../resources/js/resources/IconTemplate@2x.png');
     }


### PR DESCRIPTION
Extended the InstallsAppIcon trait to copy .ico and .icns icon formats alongside existing ones. This ensures compatibility with platforms requiring these formats.

For macOS: icon.icns
For Windows: icon.ico
Fallback: icon.png

Doc PR: https://github.com/NativePHP/nativephp.com/pull/119