### PR TITLE
Add extra sensitive files to cleanup

### DIFF
--- a/src/Commands/BundleCommand.php
+++ b/src/Commands/BundleCommand.php
@@ -236,6 +236,7 @@ class BundleCommand extends Command
                 'build', // Compiled box assets
                 'temp', // Temp files
                 'tests', // Tests
+                'auth.json', // Composer auth file
             ])
             ->exclude(config('nativephp.cleanup_exclude_files', []));
 

--- a/src/Traits/CopiesToBuildDirectory.php
+++ b/src/Traits/CopiesToBuildDirectory.php
@@ -34,6 +34,7 @@ trait CopiesToBuildDirectory
         '**/.github',
 
         // Potentially containing sensitive info
+        'auth.json', // Composer auth file
         'database/*.sqlite',
         'database/*.sqlite-shm',
         'database/*.sqlite-wal',


### PR DESCRIPTION
This pull request updates the file exclusion lists in two parts of the codebase to include the `auth.json` file, which potentially contains sensitive information. This ensures that the file is excluded during bundling and copying operations.

### File Exclusion Updates:

* [`src/Commands/BundleCommand.php`](diffhunk://#diff-9b3b84dab5d391dcf768c3ff5fc1a0edce75dfcc487379e6af7a5a7a3da200deR239): Added `auth.json` to the list of files excluded from the zip archive during the bundling process.
* [`src/Traits/CopiesToBuildDirectory.php`](diffhunk://#diff-3b7ec76d21b431dbdf1173367a4e905b01bb7e3d00675d99b3f2bff89397f8a1R37): Added `auth.json` to the list of files excluded from being copied to the build directory.