### PR TITLE
feat: add electron-builder command to publish electron-builder.js

### DIFF
--- a/src/Commands/ElectronBuilderCommand.php
+++ b/src/Commands/ElectronBuilderCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Native\Electron\Commands;
+
+use Illuminate\Console\Command;
+use Native\Electron\Traits\PublishesElectronBuilderJs;
+
+class ElectronBuilderCommand extends Command
+{
+    use PublishesElectronBuilderJs;
+
+    protected $signature = 'nativephp:electron-builder {--force} {--restore}';
+
+    public function handle(): void
+    {
+        if ($this->option('restore')) {
+            // Restore the electron-builder.js file
+            $this->restoreElectronBuilderJs();
+
+            return;
+        }
+
+        // Publish the electron-builder.js file
+        $this->publishElectronBuilderJs($this->option('force'));
+    }
+}

--- a/src/ElectronServiceProvider.php
+++ b/src/ElectronServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Application;
 use Native\Electron\Commands\BuildCommand;
 use Native\Electron\Commands\BundleCommand;
 use Native\Electron\Commands\DevelopCommand;
+use Native\Electron\Commands\ElectronBuilderCommand;
 use Native\Electron\Commands\InstallCommand;
 use Native\Electron\Commands\PublishCommand;
 use Native\Electron\Commands\ResetCommand;
@@ -27,6 +28,7 @@ class ElectronServiceProvider extends PackageServiceProvider
                 PublishCommand::class,
                 BundleCommand::class,
                 ResetCommand::class,
+                ElectronBuilderCommand::class,
             ]);
     }
 

--- a/src/Traits/PublishesElectronBuilderJs.php
+++ b/src/Traits/PublishesElectronBuilderJs.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Native\Electron\Traits;
+
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\note;
+
+trait PublishesElectronBuilderJs
+{
+    /**
+     * Publishes the electron-builder.js to the resources directory
+     * of the application.
+     *
+     * @see /resources/js/electron-builder.js
+     */
+    public function publishElectronBuilderJs(bool $force = false): void
+    {
+        intro('Publishing electron-builder.js to vendor folder ...');
+
+        // Destination path
+        $destinationPath = base_path('resources/vendor/nativephp/js/electron-builder.js');
+
+        if (file_exists($destinationPath) && ! $force) {
+            note('The file already exists. Use --force to overwrite.');
+
+            // If the file already exists we want to keep the backup
+            return;
+        }
+
+        // Path to src
+        $electronBuilderPath = __DIR__.'/../../resources/js/electron-builder.js';
+
+        // Create the destination directory if it does not exist
+        if (! file_exists(dirname($destinationPath))) {
+            mkdir(dirname($destinationPath), 0755, true);
+        }
+
+        // Copy the file to the destination
+        if (! copy($electronBuilderPath, $destinationPath)) {
+            throw new \Exception('Failed to publish the electron-builder.js to the resource directory file.');
+        }
+
+        // Updating package.json
+        note('Updating package.json ...');
+        $packageJsonPath = __DIR__.'/../../resources/js/package.json';
+
+        $packageJson = json_decode(file_get_contents($packageJsonPath), true);
+
+        // Iterate over the scripts and add the publish path after '--conf'
+        foreach ($packageJson['scripts'] as $key => $value) {
+            if (str_contains($value, '--config')) {
+                // Add the publish path to the script
+                $packageJson['scripts'][$key] = str_replace(
+                    '--config',
+                    "--config $destinationPath ",
+                    $value
+                );
+            }
+        }
+
+        // Create a backup of the original package.json if not exists
+        $originalPackageJsonPath = __DIR__.'/../../resources/js/package.json.bck';
+        if (! file_exists($originalPackageJsonPath)) {
+            copy($packageJsonPath, $originalPackageJsonPath);
+        }
+
+        // Save the updated package.json
+        file_put_contents($packageJsonPath, json_encode($packageJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * Restore the build configuration to the original state.
+     *
+     * @see /resources/js/electron-builder.js
+     */
+    public function restoreElectronBuilderJs(): void
+    {
+        intro('Restoring default electron build configuration...');
+
+        // Get the backup path
+        $originalPackageJsonPath = __DIR__.'/../../resources/js/package.json.bck';
+
+        if (! file_exists($originalPackageJsonPath)) {
+            throw new \Exception('The original package.json file does not exist.');
+        }
+
+        // Restore the original package.json file
+        $packageJsonPath = __DIR__.'/../../resources/js/package.json';
+        if (! copy($originalPackageJsonPath, $packageJsonPath)) {
+            throw new \Exception('Failed to restore the original package.json file.');
+        }
+
+        // Remove the backup file
+        if (file_exists($originalPackageJsonPath)) {
+            unlink($originalPackageJsonPath);
+        }
+    }
+}

--- a/tests/Unit/Traits/PublishesElectronBuilderJsTest.php
+++ b/tests/Unit/Traits/PublishesElectronBuilderJsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Native\Electron\Tests\Unit\Traits;
+
+use Native\Electron\Traits\PublishesElectronBuilderJs;
+
+beforeEach(function () {
+    // Set up
+    app()->setBasePath(realpath(__DIR__.'/../../../'));
+
+    // Copy the original package.json file to a backup
+    $packageJsonPath = base_path('resources/js/package.json');
+    $originalPackageJsonPath = base_path('resources/js/package.json.original');
+
+    // Create a backup of the file
+    copy($packageJsonPath, $originalPackageJsonPath);
+});
+
+afterEach(function () {
+    // Clean up after test
+    $publishPath = base_path('resources/vendor/nativephp/js/electron-builder.js');
+
+    // Remove the backup file
+    if (file_exists($publishPath)) {
+        unlink($publishPath);
+    }
+
+    // Restore the original package.json file
+    $packageJsonPath = base_path('resources/js/package.json');
+    $originalPackageJsonPath = base_path('resources/js/package.json.original');
+
+    // Restore the original file
+    if (file_exists($originalPackageJsonPath)) {
+        copy($originalPackageJsonPath, $packageJsonPath);
+
+        // Remove the original copy
+        unlink($originalPackageJsonPath);
+    }
+
+    // Remove package.json.bck
+    $packageJsonBckPath = base_path('resources/js/package.json.bck');
+    if (file_exists($packageJsonBckPath)) {
+        unlink($packageJsonBckPath);
+    }
+});
+
+it('can publish a copy of the electron-builder.js to the destination folder and update the package.json', function (object $mock) {
+    $mock->publishElectronBuilderJs();
+
+    $publishPath = base_path('resources/vendor/nativephp/js/electron-builder.js');
+
+    expect(file_exists($publishPath))->toBeTrue()
+        ->and(file_get_contents($publishPath))->not->toBe('')
+        ->and(file_get_contents($publishPath))->toBe(file_get_contents(base_path('resources/js/electron-builder.js')));
+
+    // Check if the package.json file has been updated
+    $packageJsonPath = base_path('resources/js/package.json');
+    $packageJson = json_decode(file_get_contents($packageJsonPath), true);
+    $publishPath = base_path('resources/vendor/nativephp/js/electron-builder.js');
+
+    // Check if the publish path is in the package.json
+    expect($packageJson['scripts']['build:win-x64'])->toContain('--config '.$publishPath)
+        ->and($packageJson['scripts']['build:mac-arm64'])->toContain('--config '.$publishPath)
+        ->and($packageJson['scripts']['build:mac-x86'])->toContain('--config '.$publishPath)
+        ->and($packageJson['scripts']['build:linux-x64'])->toContain('--config '.$publishPath);
+})
+    ->with([
+        // Empty class with the MergesElectronConfig trait
+        new class
+        {
+            use PublishesElectronBuilderJs;
+        },
+    ]);
+
+it('can restore the original package state', function (object $mock) {
+    // Create a backup of the original package.json file
+    $packageJsonPath = base_path('resources/js/package.json');
+    $packageJsonContents = file_get_contents($packageJsonPath);
+
+    // Publish the electron-builder.js file
+    $mock->publishElectronBuilderJs(true);
+
+    // Restore the original package.json file
+    $mock->restoreElectronBuilderJs();
+
+    // Check if the package.json file has been restored
+    expect($packageJsonContents)->toBe(file_get_contents($packageJsonPath));
+})
+    ->with([
+        // Empty class with the MergesElectronConfig trait
+        new class
+        {
+            use PublishesElectronBuilderJs;
+        },
+    ]);


### PR DESCRIPTION
Add `native:electron-builder` command to make the `electron-builder.js` file publishable to our resources directory. This would solve my need as a developer to make changes to backend building step.

---

The command creates a copy of the `electron-builder.js` provided by installing this package inside the `resources/vendor/nativephp/js`. After that I will create a backup of the `package.json` and updates the scripts section so that our copy will be used when building.

When running the command with the `--restore` option the `package.json` will be restored from a backup.