### PR TITLE
Added file to warning message relative to the copy() call

### DIFF
--- a/src/Traits/CopiesToBuildDirectory.php
+++ b/src/Traits/CopiesToBuildDirectory.php
@@ -117,7 +117,7 @@ trait CopiesToBuildDirectory
                     }
                 }
             } catch (Throwable $e) {
-                warning('[WARNING] '.$e->getMessage());
+                warning('[WARNING] '.$e->getMessage().', file: '.$item->getPathname());
             }
         }
 


### PR DESCRIPTION
Sometimes some files are considered folders (or are hidden files) and the are unable to be copied on Windows.

Showing which causes the exception to be thrown makes easy to investigate on the issue.