### PR TITLE
fix: replace callPhpSync with callPhp for storage linking

### DIFF
--- a/resources/js/electron-plugin/dist/server/php.js
+++ b/resources/js/electron-plugin/dist/server/php.js
@@ -210,7 +210,7 @@ function serveApp(secret, apiPort, phpIniSettings) {
         });
         if (!runningSecureBuild()) {
             console.log('Linking storage path...');
-            callPhpSync(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings);
+            callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings);
         }
         if (shouldOptimize(store)) {
             console.log('Caching view and routes...');

--- a/resources/js/electron-plugin/src/server/php.ts
+++ b/resources/js/electron-plugin/src/server/php.ts
@@ -320,7 +320,7 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
               * (whether it's a secured bundle or not), so symlinking feels redundant
              */
             console.log('Linking storage path...');
-            callPhpSync(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings)
+            callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings)
         }
 
         // Cache the project


### PR DESCRIPTION
I didn't find the source of the problem, but this fixed my `native:serve` hanging.