### PR TITLE
fix: take into account all changed keys

### DIFF
--- a/resources/js/electron-plugin/dist/server/state.js
+++ b/resources/js/electron-plugin/dist/server/state.js
@@ -2,16 +2,16 @@ import Store from "electron-store";
 import { notifyLaravel } from "./utils.js";
 const settingsStore = new Store();
 settingsStore.onDidAnyChange((newValue, oldValue) => {
-    const changedKey = Object.keys(newValue).find((key) => newValue[key] !== oldValue[key]);
-    if (changedKey) {
+    const changedKeys = Object.keys(newValue).filter((key) => newValue[key] !== oldValue[key]);
+    changedKeys.forEach((key) => {
         notifyLaravel("events", {
             event: "Native\\Laravel\\Events\\Settings\\SettingChanged",
             payload: {
-                key: changedKey,
-                value: newValue[changedKey] || null,
+                key,
+                value: newValue[key] || null,
             },
         });
-    }
+    });
 });
 function generateRandomString(length) {
     let result = "";

--- a/resources/js/electron-plugin/src/server/state.ts
+++ b/resources/js/electron-plugin/src/server/state.ts
@@ -5,19 +5,17 @@ import { notifyLaravel } from "./utils.js";
 const settingsStore = new Store();
 settingsStore.onDidAnyChange((newValue, oldValue) => {
   // Only notify of the changed key/value pair
-  const changedKey = Object.keys(newValue).find(
-    (key) => newValue[key] !== oldValue[key]
-  );
+  const changedKeys = Object.keys(newValue).filter((key) => newValue[key] !== oldValue[key]);
 
-  if (changedKey) {
+  changedKeys.forEach((key) => {
     notifyLaravel("events", {
       event: "Native\\Laravel\\Events\\Settings\\SettingChanged",
       payload: {
-        key: changedKey,
-        value: newValue[changedKey] || null,
+        key,
+          value: newValue[key] || null,
       },
     });
-  }
+  });
 });
 
 interface State {


### PR DESCRIPTION
Fix: Account for all changed keys in settingsStore.onDidAnyChange

This commit addresses an issue where only the *first* changed key was being processed when multiple settings were updated simultaneously. The previous implementation used `Object.keys(newValue).find()` which stops after finding the first difference.

The updated code now iterates through *all* keys in the `newValue` object and compares them to their corresponding values in `oldValue`. This ensures that every changed setting triggers the `notifyLaravel` function, providing a complete and accurate representation of settings modifications.

Specifically, this change is crucial in scenarios where:

*   `clear()` or `reset()` are called on the settings store.
*   Multiple settings are updated within a single operation.
*   The application is running in watch mode, where consistent updates are expected.

The `Object.keys(newValue).filter()` method now obtains all changed keys, which are each sent to the `notifyLaravel` to update the backend for each relevant setting.

---

I made the same pull request before, but deleted the fork of the repository, not knowing the side effects (this closed the pull request).

Previous pull request <https://github.com/NativePHP/electron/pull/210>