### PR TITLE
remove storage:link

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Commit changes
         if: github.event_name == 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Build plugin
 

--- a/resources/js/electron-plugin/dist/server/php.js
+++ b/resources/js/electron-plugin/dist/server/php.js
@@ -208,10 +208,6 @@ function serveApp(secret, apiPort, phpIniSettings) {
         const store = new Store({
             name: 'nativephp',
         });
-        if (!runningSecureBuild()) {
-            console.log('Linking storage path...');
-            callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings);
-        }
         if (shouldOptimize(store)) {
             console.log('Caching view and routes...');
             let result = callPhpSync(['artisan', 'optimize'], phpOptions, phpIniSettings);

--- a/resources/js/electron-plugin/src/server/php.ts
+++ b/resources/js/electron-plugin/src/server/php.ts
@@ -311,18 +311,6 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
             name: 'nativephp', // So it doesn't conflict with settings of the app
         });
 
-        // Make sure the storage path is linked - as people can move the app around, we
-        // need to run this every time the app starts
-        if (!runningSecureBuild()) {
-            /*
-              * Simon: Note for later that we should strip out using storage:link
-              * all of the necessary files for the app to function should be a part of the bundle
-              * (whether it's a secured bundle or not), so symlinking feels redundant
-             */
-            console.log('Linking storage path...');
-            callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings)
-        }
-
         // Cache the project
         if (shouldOptimize(store)) {
             console.log('Caching view and routes...');


### PR DESCRIPTION
Symlinks have been discouraged as per the docs for some time.

We still ran `storage:link` under the hood. The command is invoked in a separate process, thus did not prevent the app from working. But it did fill up the logs as reported by some users https://github.com/NativePHP/laravel/issues/601

This PR removes it.

@simonhamp Do you want this mentioned in the docs explicitly?