### PR TITLE
[WIP] feat: add electron initialization scripts support

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -4,4 +4,15 @@ return [
     'hot_reload' => [
         base_path('app/Providers/NativeAppServiceProvider.php'),
     ],
+
+    /**
+     * Custom JavaScript scripts to execute during Electron initialization.
+     * These scripts run after state setup but before app.whenReady().
+     */
+    'electron_init_scripts' => [
+        // Examples of custom initialization scripts
+        // 'const { initializeModule } = require("my-electron-module"); initializeModule();',
+        // 'const customSetup = require("another-package"); customSetup.configure({option: true});',
+        // 'console.log("Custom Electron initialization complete");',
+    ],
 ];

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -10,9 +10,6 @@ return [
      * These scripts run after state setup but before app.whenReady().
      */
     'electron_init_scripts' => [
-        // Examples of custom initialization scripts
         // 'const { initializeModule } = require("my-electron-module"); initializeModule();',
-        // 'const customSetup = require("another-package"); customSetup.configure({option: true});',
-        // 'console.log("Custom Electron initialization complete");',
     ],
 ];

--- a/resources/js/electron-plugin/dist/index.js
+++ b/resources/js/electron-plugin/dist/index.js
@@ -26,12 +26,15 @@ class NativePHP {
         this.mainWindow = null;
     }
     bootstrap(app, icon, phpBinary, cert) {
-        initialize();
-        state.icon = icon;
-        state.php = phpBinary;
-        state.caCert = cert;
-        this.bootstrapApp(app);
-        this.addEventListeners(app);
+        return __awaiter(this, void 0, void 0, function* () {
+            initialize();
+            state.icon = icon;
+            state.php = phpBinary;
+            state.caCert = cert;
+            yield this.initializeCustomScripts();
+            this.bootstrapApp(app);
+            this.addEventListeners(app);
+        });
     }
     addEventListeners(app) {
         app.on("open-url", (event, url) => {
@@ -108,6 +111,28 @@ class NativePHP {
                 console.error(error);
             }
             return config;
+        });
+    }
+    initializeCustomScripts() {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                const config = yield this.loadConfig();
+                const scripts = (config === null || config === void 0 ? void 0 : config.electron_init_scripts) || [];
+                if (scripts.length === 0) {
+                    return;
+                }
+                scripts.forEach((script, index) => {
+                    try {
+                        eval(script);
+                    }
+                    catch (error) {
+                        console.error(error);
+                    }
+                });
+            }
+            catch (error) {
+                console.error(error);
+            }
         });
     }
     setDockIcon() {

--- a/resources/js/electron-plugin/src/index.ts
+++ b/resources/js/electron-plugin/src/index.ts
@@ -25,7 +25,7 @@ class NativePHP {
   schedulerInterval = undefined;
   mainWindow = null;
 
-  public bootstrap(
+  public async bootstrap(
     app: CrossProcessExports.App,
     icon: string,
     phpBinary: string,
@@ -37,6 +37,9 @@ class NativePHP {
     state.icon = icon;
     state.php = phpBinary;
     state.caCert = cert;
+
+    // Execute custom initialization scripts
+    await this.initializeCustomScripts();
 
     this.bootstrapApp(app);
     this.addEventListeners(app);
@@ -143,6 +146,27 @@ class NativePHP {
     }
 
     return config;
+  }
+
+  private async initializeCustomScripts() {
+    try {
+      const config = await this.loadConfig() as any;
+      const scripts = config?.electron_init_scripts || [];
+      
+      if (scripts.length === 0) {
+        return;
+      }
+      
+      scripts.forEach((script: string, index: number) => {
+        try {
+          eval(script);
+        } catch (error) {
+          console.error(error);
+        }
+      });
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   private setDockIcon() {


### PR DESCRIPTION
Add custom JavaScript script execution during Electron initialization:
- New electron_init_scripts configuration option in nativephp.php
- Scripts execute after state setup but before app.whenReady()
- Robust error handling for individual script failures
- Backward compatible (empty array by default)