### PR TITLE
use vendor cacert.pem for custom binaries

### DIFF
--- a/src/Traits/CopiesCertificateAuthority.php
+++ b/src/Traits/CopiesCertificateAuthority.php
@@ -17,13 +17,6 @@ trait CopiesCertificateAuthority
 
             $phpBinaryDirectory = base_path('vendor/nativephp/php-bin/');
 
-            // Check if the class this trait is used in also uses LocatesPhpBinary
-            /* @phpstan-ignore-next-line */
-            if (method_exists($this, 'phpBinaryPath')) {
-                // Get binary directory but up one level
-                $phpBinaryDirectory = dirname(base_path($this->phpBinaryPath()));
-            }
-
             $certificateFileName = 'cacert.pem';
             $certFilePath = Path::join($phpBinaryDirectory, $certificateFileName);
 


### PR DESCRIPTION
When using custom PHP binaries the `CopiesCertificateAuthority` trait would look for the `cacert.pem` file relative to the custom binary path. 

It's not documented that users should provider their own certificate bundle in this case. I see no reason why we should not use the default certs used by `php-bin`. Since we include the repo by default it should always be there & be updated.

This PR removes the conditional & makes sure the certs in `vendor/nativephp/php-bin/cacert.pem` are always used.

Fixes: https://github.com/NativePHP/laravel/issues/655


