### PR TITLE
Only trigger notarization hook on Mac build target

### DIFF
--- a/resources/js/build/notarize.js
+++ b/resources/js/build/notarize.js
@@ -1,7 +1,11 @@
 import { notarize } from '@electron/notarize';
 
 export default async (context) => {
-    if (process.platform !== 'darwin') return
+    // Only notarize when process is running on a Mac
+    if (process.platform !== 'darwin') return;
+
+    // And the current build target is macOS
+    if (context.packager.platform.name !== 'mac') return;
 
     console.log('aftersign hook triggered, start to notarize app.')
 


### PR DESCRIPTION
The after sign hook was only checking if the process was running on a Mac, but didn't take the build target into account. 

This pull request adds a small guard clause to the `notarize.js` file to ensure notarization only occurs for macOS builds.

Fixes: https://github.com/NativePHP/laravel/issues/653