### PR TITLE
Add `skipTaskbar` and `hiddenInMissionControl` properties to window API

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/window.js
+++ b/resources/js/electron-plugin/dist/server/api/window.js
@@ -139,7 +139,7 @@ function getWindowData(id) {
     };
 }
 router.post('/open', (req, res) => {
-    let { id, x, y, frame, width, height, minWidth, minHeight, maxWidth, maxHeight, focusable, hasShadow, url, resizable, movable, minimizable, maximizable, closable, title, alwaysOnTop, titleBarStyle, trafficLightPosition, vibrancy, backgroundColor, transparency, showDevTools, fullscreen, fullscreenable, kiosk, autoHideMenuBar, webPreferences, } = req.body;
+    let { id, x, y, frame, width, height, minWidth, minHeight, maxWidth, maxHeight, focusable, skipTaskbar, hiddenInMissionControl, hasShadow, url, resizable, movable, minimizable, maximizable, closable, title, alwaysOnTop, titleBarStyle, trafficLightPosition, vibrancy, backgroundColor, transparency, showDevTools, fullscreen, fullscreenable, kiosk, autoHideMenuBar, webPreferences, } = req.body;
     if (state.windows[id]) {
         state.windows[id].show();
         state.windows[id].focus();
@@ -179,6 +179,8 @@ router.post('/open', (req, res) => {
         trafficLightPosition,
         vibrancy,
         focusable,
+        skipTaskbar,
+        hiddenInMissionControl,
         autoHideMenuBar }, (process.platform === 'linux' ? { icon: state.icon } : {})), { webPreferences: Object.assign(Object.assign({}, webPreferences), defaultWebPreferences), fullscreen,
         fullscreenable,
         kiosk }));

--- a/resources/js/electron-plugin/src/server/api/window.ts
+++ b/resources/js/electron-plugin/src/server/api/window.ts
@@ -203,6 +203,8 @@ router.post('/open', (req, res) => {
         maxWidth,
         maxHeight,
         focusable,
+        skipTaskbar,
+        hiddenInMissionControl,
         hasShadow,
         url,
         resizable,
@@ -283,6 +285,8 @@ router.post('/open', (req, res) => {
         trafficLightPosition,
         vibrancy,
         focusable,
+        skipTaskbar,
+        hiddenInMissionControl,
         autoHideMenuBar,
         ...(process.platform === 'linux' ? {icon: state.icon} : {}),
         webPreferences: {


### PR DESCRIPTION
Enhanced the window API by including support for the `skipTaskbar` and `hiddenInMissionControl` properties, enabling more control over window visibility and behavior.

PR
NativePHP/laravel: https://github.com/NativePHP/laravel/pull/671