### PR TITLE
remove workingDirectory from Windows deep-link handler

### DIFF
--- a/resources/js/electron-plugin/dist/index.js
+++ b/resources/js/electron-plugin/dist/index.js
@@ -149,7 +149,6 @@ class NativePHP {
                             event: "\\Native\\Laravel\\Events\\App\\OpenedFromURL",
                             payload: {
                                 url: commandLine[commandLine.length - 1],
-                                workingDirectory: workingDirectory,
                             },
                         });
                     });

--- a/resources/js/electron-plugin/src/index.ts
+++ b/resources/js/electron-plugin/src/index.ts
@@ -201,7 +201,6 @@ class NativePHP {
                                 event: "\\Native\\Laravel\\Events\\App\\OpenedFromURL",
                                 payload: {
                                     url: commandLine[commandLine.length - 1],
-                                    workingDirectory: workingDirectory,
                                 },
                             });
                         },


### PR DESCRIPTION
Deeplink handling on Windows was passing a `workingDirectory` parameter to the `OpenedFromURL` event.

This was causing issues when opening deep-links on Windows

Fixes: https://github.com/NativePHP/laravel/issues/599