### PR TITLE
add `storage/hot` to exclude files

### DIFF
--- a/src/Traits/CopiesToBuildDirectory.php
+++ b/src/Traits/CopiesToBuildDirectory.php
@@ -44,6 +44,7 @@ trait CopiesToBuildDirectory
         'storage/framework/cache/*',
         'storage/framework/views/*',
         'storage/logs/*',
+        'storage/hot',
 
         // Only needed for local testing
         'vendor/nativephp/electron/resources',


### PR DESCRIPTION
This PR makes sure the `storage/hot` file isn't included in builds.

Fixes: https://github.com/NativePHP/laravel/issues/510