### PR TITLE
Fix port conflicts when running multiple NativePHP apps on Windows

### DIFF
--- a/resources/js/electron-plugin/tests/api.test.ts
+++ b/resources/js/electron-plugin/tests/api.test.ts
@@ -31,6 +31,9 @@ describe('API test', () => {
     });
 
     it('starts API server on port 4000', async () => {
+        // NOTE: If this fails it may be you have a NativePHP app running locally
+        // and the port negotiation actually woks as expected (might be 4001).
+        // Quit any running NativePHP apps to verify.
         expect(apiServer.port).toBe(4000);
     });
 


### PR DESCRIPTION
Multiple NativePHP applications cannot run simultaneously on Windows due to port binding conflicts. The second app fails with exit code 4294967294 (`EADDRINUSE`) and `net::ERR_NAME_NOT_RESOLVED` errors.

See issue https://github.com/NativePHP/laravel/issues/651

`getPort` sometimes reports ports as available when they're actually bound by another process. This happens due to Windows-specific port detection issues, including `TIME_WAIT` states and reserved port ranges that get-port doesn't properly detect.

## Proposed fix

Enhanced getPhpPort() to validate that suggested ports are actually bindable:

1. Fast path: Try get-port first (works in 99% of cases)
2. Validation: Test binding to the suggested port with a real TCP server
3. Smart fallback: If validation fails, incrementally search from suggestedPort + 1 upward