### PR TITLE
cleanup stray scheduler processes

### DIFF
--- a/resources/js/electron-plugin/dist/index.js
+++ b/resources/js/electron-plugin/dist/index.js
@@ -213,8 +213,9 @@ class NativePHP {
             .forEach((process) => {
             if (!process || !process.pid)
                 return;
+            if (process.killed && process.exitCode !== null)
+                return;
             try {
-                process.kill(0);
                 killSync(process.pid, 'SIGTERM', true);
                 ps.kill(process.pid);
             }

--- a/resources/js/electron-plugin/dist/index.js
+++ b/resources/js/electron-plugin/dist/index.js
@@ -11,7 +11,7 @@ import { app, session, powerMonitor } from "electron";
 import { initialize } from "@electron/remote/main/index.js";
 import state from "./server/state.js";
 import { electronApp, optimizer } from "@electron-toolkit/utils";
-import { retrieveNativePHPConfig, retrievePhpIniSettings, runScheduler, startAPI, startPhpApp, } from "./server/index.js";
+import { retrieveNativePHPConfig, retrievePhpIniSettings, runScheduler, killScheduler, startAPI, startPhpApp, } from "./server/index.js";
 import { notifyLaravel } from "./server/utils.js";
 import { resolve } from "path";
 import { stopAllProcesses } from "./server/api/childProcess.js";
@@ -22,8 +22,8 @@ const { autoUpdater } = electronUpdater;
 class NativePHP {
     constructor() {
         this.processes = [];
-        this.schedulerInterval = undefined;
         this.mainWindow = null;
+        this.schedulerInterval = undefined;
     }
     bootstrap(app, icon, phpBinary, cert) {
         initialize();
@@ -192,6 +192,7 @@ class NativePHP {
             clearInterval(this.schedulerInterval);
             this.schedulerInterval = null;
         }
+        killScheduler();
     }
     startScheduler() {
         const now = new Date();
@@ -206,10 +207,14 @@ class NativePHP {
         }, delay);
     }
     killChildProcesses() {
+        this.stopScheduler();
         this.processes
             .filter((p) => p !== undefined)
             .forEach((process) => {
+            if (!process || !process.pid)
+                return;
             try {
+                process.kill(0);
                 killSync(process.pid, 'SIGTERM', true);
                 ps.kill(process.pid);
             }

--- a/resources/js/electron-plugin/dist/server/index.js
+++ b/resources/js/electron-plugin/dist/server/index.js
@@ -11,6 +11,7 @@ import startAPIServer from "./api.js";
 import { retrieveNativePHPConfig, retrievePhpIniSettings, serveApp, startScheduler, } from "./php.js";
 import { appendCookie } from "./utils.js";
 import state from "./state.js";
+let schedulerProcess = null;
 export function startPhpApp() {
     return __awaiter(this, void 0, void 0, function* () {
         const result = yield serveApp(state.randomSecret, state.electronApiPort, state.phpIni);
@@ -20,7 +21,14 @@ export function startPhpApp() {
     });
 }
 export function runScheduler() {
-    startScheduler(state.randomSecret, state.electronApiPort, state.phpIni);
+    killScheduler();
+    schedulerProcess = startScheduler(state.randomSecret, state.electronApiPort, state.phpIni);
+}
+export function killScheduler() {
+    if (schedulerProcess && !schedulerProcess.killed) {
+        schedulerProcess.kill();
+        schedulerProcess = null;
+    }
 }
 export function startAPI() {
     return startAPIServer(state.randomSecret);

--- a/resources/js/electron-plugin/src/index.ts
+++ b/resources/js/electron-plugin/src/index.ts
@@ -277,7 +277,10 @@ class NativePHP {
     this.processes
       .filter((p) => p !== undefined)
       .forEach((process) => {
+        if (!process || !process.pid) return;
+
         try {
+          process.kill(0); // Test if process exists (throws error if not)
           // @ts-ignore
           killSync(process.pid, 'SIGTERM', true); // Kill tree
           ps.kill(process.pid); // Sometimes does not kill the subprocess of php server

--- a/resources/js/electron-plugin/src/index.ts
+++ b/resources/js/electron-plugin/src/index.ts
@@ -278,15 +278,18 @@ class NativePHP {
       .filter((p) => p !== undefined)
       .forEach((process) => {
         if (!process || !process.pid) return;
+        if (process.killed && process.exitCode !== null) return;
 
         try {
-          process.kill(0); // Test if process exists (throws error if not)
-          // @ts-ignore
-          killSync(process.pid, 'SIGTERM', true); // Kill tree
-          ps.kill(process.pid); // Sometimes does not kill the subprocess of php server
+
+            // @ts-ignore
+            killSync(process.pid, 'SIGTERM', true); // Kill tree
+            ps.kill(process.pid); // Sometimes does not kill the subprocess of php server
+
         } catch (err) {
           console.error(err);
         }
+
       });
   }
 }

--- a/resources/js/electron-plugin/src/index.ts
+++ b/resources/js/electron-plugin/src/index.ts
@@ -7,6 +7,7 @@ import {
   retrieveNativePHPConfig,
   retrievePhpIniSettings,
   runScheduler,
+  killScheduler,
   startAPI,
   startPhpApp,
 } from "./server/index.js";
@@ -22,8 +23,8 @@ const { autoUpdater } = electronUpdater;
 
 class NativePHP {
   processes = [];
-  schedulerInterval = undefined;
   mainWindow = null;
+  schedulerInterval = undefined;
 
   public bootstrap(
     app: CrossProcessExports.App,
@@ -244,12 +245,13 @@ class NativePHP {
   }
 
 
-    private stopScheduler() {
-        if (this.schedulerInterval) {
-            clearInterval(this.schedulerInterval);
-            this.schedulerInterval = null;
-        }
-    }
+  private stopScheduler() {
+      if (this.schedulerInterval) {
+          clearInterval(this.schedulerInterval);
+          this.schedulerInterval = null;
+      }
+      killScheduler();
+  }
 
   private startScheduler() {
     const now = new Date();
@@ -270,6 +272,8 @@ class NativePHP {
   }
 
   private killChildProcesses() {
+    this.stopScheduler();
+
     this.processes
       .filter((p) => p !== undefined)
       .forEach((process) => {

--- a/resources/js/electron-plugin/src/index.ts
+++ b/resources/js/electron-plugin/src/index.ts
@@ -1,5 +1,6 @@
 import CrossProcessExports from "electron";
 import { app, session, powerMonitor } from "electron";
+import { ChildProcessWithoutNullStreams } from "child_process";
 import { initialize } from "@electron/remote/main/index.js";
 import state from "./server/state.js";
 import { electronApp, optimizer } from "@electron-toolkit/utils";
@@ -22,7 +23,7 @@ import electronUpdater from 'electron-updater';
 const { autoUpdater } = electronUpdater;
 
 class NativePHP {
-  processes = [];
+  processes: ChildProcessWithoutNullStreams[] = [];
   mainWindow = null;
   schedulerInterval = undefined;
 
@@ -281,10 +282,9 @@ class NativePHP {
         if (process.killed && process.exitCode !== null) return;
 
         try {
-
-            // @ts-ignore
-            killSync(process.pid, 'SIGTERM', true); // Kill tree
-            ps.kill(process.pid); // Sometimes does not kill the subprocess of php server
+          // @ts-ignore
+          killSync(process.pid, 'SIGTERM', true); // Kill tree
+          ps.kill(process.pid); // Sometimes does not kill the subprocess of php server
 
         } catch (err) {
           console.error(err);

--- a/resources/js/electron-plugin/src/server/api/childProcess.ts
+++ b/resources/js/electron-plugin/src/server/api/childProcess.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import {utilityProcess} from 'electron';
+import {utilityProcess, UtilityProcess} from 'electron';
 import state from '../state.js';
 import {notifyLaravel} from "../utils.js";
 import {getAppPath, getDefaultEnvironmentVariables, getDefaultPhpIniSettings, runningSecureBuild} from "../php.js";
@@ -207,7 +207,7 @@ export function stopAllProcesses() {
     }
 }
 
-function getProcess(alias) {
+function getProcess(alias: string): UtilityProcess | undefined {
     return state.processes[alias]?.proc;
 }
 

--- a/resources/js/electron-plugin/src/server/index.ts
+++ b/resources/js/electron-plugin/src/server/index.ts
@@ -7,6 +7,9 @@ import {
 } from "./php.js";
 import { appendCookie } from "./utils.js";
 import state from "./state.js";
+import { ChildProcess } from "child_process";
+
+let schedulerProcess: ChildProcess | null = null;
 
 export async function startPhpApp() {
   const result = await serveApp(
@@ -23,7 +26,15 @@ export async function startPhpApp() {
 }
 
 export function runScheduler() {
-  startScheduler(state.randomSecret, state.electronApiPort, state.phpIni);
+  killScheduler();
+  schedulerProcess = startScheduler(state.randomSecret, state.electronApiPort, state.phpIni);
+}
+
+export function killScheduler() {
+  if (schedulerProcess && !schedulerProcess.killed) {
+    schedulerProcess.kill();
+    schedulerProcess = null;
+  }
 }
 
 export function startAPI(): Promise<APIProcess> {


### PR DESCRIPTION
This PR ensures that only one scheduler process runs at a time and that it is properly terminated when needed. The changes add functionality to explicitly kill the scheduler process, preventing potential orphaned processes

Potentially related: https://github.com/NativePHP/laravel/issues/542

