### PR TITLE
Add support for setting zoom factor on windows

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/window.js
+++ b/resources/js/electron-plugin/dist/server/api/window.js
@@ -53,6 +53,12 @@ router.post('/hide-dev-tools', (req, res) => {
     (_a = state.windows[id]) === null || _a === void 0 ? void 0 : _a.webContents.closeDevTools();
     res.sendStatus(200);
 });
+router.post('/set-zoom-factor', (req, res) => {
+    var _a;
+    const { id, zoomFactor } = req.body;
+    (_a = state.windows[id]) === null || _a === void 0 ? void 0 : _a.webContents.setZoomFactor(parseFloat(zoomFactor));
+    res.sendStatus(200);
+});
 router.post('/position', (req, res) => {
     var _a;
     const { id, x, y, animate } = req.body;
@@ -139,7 +145,7 @@ function getWindowData(id) {
     };
 }
 router.post('/open', (req, res) => {
-    let { id, x, y, frame, width, height, minWidth, minHeight, maxWidth, maxHeight, focusable, skipTaskbar, hiddenInMissionControl, hasShadow, url, resizable, movable, minimizable, maximizable, closable, title, alwaysOnTop, titleBarStyle, trafficLightPosition, vibrancy, backgroundColor, transparency, showDevTools, fullscreen, fullscreenable, kiosk, autoHideMenuBar, webPreferences, } = req.body;
+    let { id, x, y, frame, width, height, minWidth, minHeight, maxWidth, maxHeight, focusable, skipTaskbar, hiddenInMissionControl, hasShadow, url, resizable, movable, minimizable, maximizable, closable, title, alwaysOnTop, titleBarStyle, trafficLightPosition, vibrancy, backgroundColor, transparency, showDevTools, fullscreen, fullscreenable, kiosk, autoHideMenuBar, webPreferences, zoomFactor, } = req.body;
     if (state.windows[id]) {
         state.windows[id].show();
         state.windows[id].focus();
@@ -247,6 +253,9 @@ router.post('/open', (req, res) => {
     });
     url = appendWindowIdToUrl(url, id);
     window.loadURL(url);
+    window.webContents.on('dom-ready', () => {
+        window.webContents.setZoomFactor(parseFloat(zoomFactor));
+    });
     window.webContents.on('did-finish-load', () => {
         window.show();
     });

--- a/resources/js/electron-plugin/src/server/api/window.ts
+++ b/resources/js/electron-plugin/src/server/api/window.ts
@@ -73,6 +73,14 @@ router.post('/hide-dev-tools', (req, res) => {
     res.sendStatus(200);
 });
 
+router.post('/set-zoom-factor', (req, res) => {
+    const {id, zoomFactor} = req.body;
+
+    state.windows[id]?.webContents.setZoomFactor(parseFloat(zoomFactor));
+
+    res.sendStatus(200);
+});
+
 router.post('/position', (req, res) => {
     const {id, x, y, animate} = req.body;
 
@@ -225,6 +233,7 @@ router.post('/open', (req, res) => {
         kiosk,
         autoHideMenuBar,
         webPreferences,
+        zoomFactor,
     } = req.body;
 
     if (state.windows[id]) {
@@ -376,6 +385,10 @@ router.post('/open', (req, res) => {
     url = appendWindowIdToUrl(url, id);
 
     window.loadURL(url);
+
+    window.webContents.on('dom-ready', () => {
+        window.webContents.setZoomFactor(parseFloat(zoomFactor));
+    });
 
     window.webContents.on('did-finish-load', () => {
         window.show();


### PR DESCRIPTION
**This PR introduces the ability to set a custom zoom factor for newly created or already open windows.**

This can be especially useful in scenarios where you do _not_ have control over the content being displayed within a window. For example, our team is currently working on a kiosk-style application that opens secondary windows to display certain (semi-)external websites. As the application will be shown on devices with a large resolution, I was searching for a way to scale the content for better readability and accessibility.
While NativePHP already allows passing options to the `webPreferences`, including a `zoomFactor`, this approach has a weird limitation: The zoom factor is applied once and then "sticks" to the domain, making it impossible to adjust later on (even if you close and reopen the window).

With this change, you can now programmatically set the zoom level at runtime using Electron’s `webContents.setZoomFactor()`, giving you more flexibility when dealing with third-party content (or even own content if you don't want to implement a custom scaling possibility). The zoom factor is the zoom percent divided by 100, so let's say you want a 125% zoom, you would pass the value 1.25.

_Laravel PR:_ https://github.com/NativePHP/laravel/pull/678

If there's anything you'd like me to tweak or improve in this PR, please let me know. 😊