### PR TITLE
Add Electron API endpoints for app locale information

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/app.js
+++ b/resources/js/electron-plugin/dist/server/api/app.js
@@ -22,6 +22,21 @@ router.get('/is-hidden', (req, res) => {
         is_hidden: app.isHidden(),
     });
 });
+router.get('/locale', (req, res) => {
+    res.json({
+        locale: app.getLocale(),
+    });
+});
+router.get('/locale-country-code', (req, res) => {
+    res.json({
+        locale_country_code: app.getLocaleCountryCode(),
+    });
+});
+router.get('/system-locale', (req, res) => {
+    res.json({
+        system_locale: app.getSystemLocale(),
+    });
+});
 router.get('/app-path', (req, res) => {
     res.json({
         path: app.getAppPath(),

--- a/resources/js/electron-plugin/src/server/api/app.ts
+++ b/resources/js/electron-plugin/src/server/api/app.ts
@@ -28,6 +28,24 @@ router.get('/is-hidden', (req, res) => {
     })
 });
 
+router.get('/locale', (req, res) => {
+    res.json({
+        locale: app.getLocale(),
+    })
+});
+
+router.get('/locale-country-code', (req, res) => {
+    res.json({
+        locale_country_code: app.getLocaleCountryCode(),
+    })
+});
+
+router.get('/system-locale', (req, res) => {
+    res.json({
+        system_locale: app.getSystemLocale(),
+    })
+});
+
 router.get('/app-path', (req, res) => {
     res.json({
         path: app.getAppPath(),


### PR DESCRIPTION
**This PR allows developers to obtain localisation information of the application and the system via the `App` facade.**

It adds three new methods to the facade that are proxies for the Electron methods `app.getLocale()`, `app.getLocaleCountryCode()`, and `app.getSystemLocale()` (see details on the [Electron documentation](https://www.electronjs.org/docs/latest/api/app#appgetlocale)). This allows developers to improve the localisation of their application, e.g. by automatically setting or suggesting a language that matches the system language when a NativePHP application is first launched.

_Laravel PR:_ <tbd>
_Docs PR:_ <tbd>

If there's anything you'd like me to tweak or improve in this PR, please let me know. 😊