### PR TITLE
Allow optional suppression of opening sub-windows

### DIFF
--- a/resources/js/electron-plugin/dist/server/api/window.js
+++ b/resources/js/electron-plugin/dist/server/api/window.js
@@ -145,7 +145,7 @@ function getWindowData(id) {
     };
 }
 router.post('/open', (req, res) => {
-    let { id, x, y, frame, width, height, minWidth, minHeight, maxWidth, maxHeight, focusable, skipTaskbar, hiddenInMissionControl, hasShadow, url, resizable, movable, minimizable, maximizable, closable, title, alwaysOnTop, titleBarStyle, trafficLightPosition, vibrancy, backgroundColor, transparency, showDevTools, fullscreen, fullscreenable, kiosk, autoHideMenuBar, webPreferences, zoomFactor, } = req.body;
+    let { id, x, y, frame, width, height, minWidth, minHeight, maxWidth, maxHeight, focusable, skipTaskbar, hiddenInMissionControl, hasShadow, url, resizable, movable, minimizable, maximizable, closable, title, alwaysOnTop, titleBarStyle, trafficLightPosition, vibrancy, backgroundColor, transparency, showDevTools, fullscreen, fullscreenable, kiosk, autoHideMenuBar, webPreferences, zoomFactor, suppressNewWindows, } = req.body;
     if (state.windows[id]) {
         state.windows[id].show();
         state.windows[id].focus();
@@ -196,6 +196,11 @@ router.post('/open', (req, res) => {
     enable(window.webContents);
     if (req.body.rememberState === true) {
         windowState === null || windowState === void 0 ? void 0 : windowState.manage(window);
+    }
+    if (suppressNewWindows) {
+        window.webContents.setWindowOpenHandler(() => {
+            return { action: "deny" };
+        });
     }
     window.on('blur', () => {
         notifyLaravel('events', {

--- a/resources/js/electron-plugin/src/server/api/window.ts
+++ b/resources/js/electron-plugin/src/server/api/window.ts
@@ -234,6 +234,7 @@ router.post('/open', (req, res) => {
         autoHideMenuBar,
         webPreferences,
         zoomFactor,
+        suppressNewWindows,
     } = req.body;
 
     if (state.windows[id]) {
@@ -315,6 +316,12 @@ router.post('/open', (req, res) => {
 
     if (req.body.rememberState === true) {
         windowState?.manage(window);
+    }
+
+    if (suppressNewWindows) {
+        window.webContents.setWindowOpenHandler(() => {
+            return { action: "deny" };
+        });
     }
 
     window.on('blur', () => {


### PR DESCRIPTION
**This PR allows developers to disable the opening of potentially unwanted pop-up windows.**

By default, Electron doesn't prevent sub-windows to be opened out of a window. This would for instance be the case if a user middle-clicks a link. This behaviour is potentially undesirable in a desktop application, as it enables the user to "break out" of a window.

To prevent additional windows from opening, this PR adds a `suppressNewWindows()` method that can be applied when opening a new window. It will prevent any pop-up windows being opened.

_Laravel PR:_ https://github.com/NativePHP/laravel/pull/685
_Docs PR:_ https://github.com/NativePHP/nativephp.com/pull/200

If there's anything you'd like me to tweak or improve in this PR, please let me know. 😊