### PR TITLE
Allow overwriting of default web preferences

### DIFF
--- a/resources/js/electron-plugin/src/server/api/window.ts
+++ b/resources/js/electron-plugin/src/server/api/window.ts
@@ -302,8 +302,8 @@ router.post('/open', (req, res) => {
         autoHideMenuBar,
         ...(process.platform === 'linux' ? {icon: state.icon} : {}),
         webPreferences: {
-            ...webPreferences,
-            ...defaultWebPreferences
+            ...defaultWebPreferences,
+            ...webPreferences
         },
         fullscreen,
         fullscreenable,


### PR DESCRIPTION
**This PR will allow the user to overwrite NativePHP's default web preferences passed to Electron.**

At the time of creating this PR, these are `backgroundThrottling`, `spellcheck`, `preload`, `sandbox`, `contextIsolation`, and `nodeIntegration`. See details here: https://github.com/NativePHP/laravel/issues/688