### PR TITLE
Better webPreferences defaults

### DIFF
--- a/resources/js/electron-plugin/dist/preload/index.mjs
+++ b/resources/js/electron-plugin/dist/preload/index.mjs
@@ -51,7 +51,7 @@ ipcRenderer.on('native-event', (event, data) => {
         });
     }
 });
-contextBridge.exposeInMainWorld('_native_init', (function () {
+contextBridge.exposeInMainWorld('native:initialized', (function () {
     window.dispatchEvent(new CustomEvent('native:init'));
-    delete window['_native_init'];
+    return true;
 })());

--- a/resources/js/electron-plugin/dist/preload/index.mjs
+++ b/resources/js/electron-plugin/dist/preload/index.mjs
@@ -1,5 +1,5 @@
 import remote from "@electron/remote";
-import { ipcRenderer } from "electron";
+import { ipcRenderer, contextBridge } from "electron";
 const Native = {
     on: (event, callback) => {
         ipcRenderer.on('native-event', (_, data) => {
@@ -15,8 +15,7 @@ const Native = {
         menu.popup({ window: remote.getCurrentWindow() });
     }
 };
-window.Native = Native;
-window.remote = remote;
+contextBridge.exposeInMainWorld('Native', Native);
 ipcRenderer.on('log', (event, { level, message, context }) => {
     if (level === 'error') {
         console.error(`[${level}] ${message}`, context);
@@ -52,3 +51,7 @@ ipcRenderer.on('native-event', (event, data) => {
         });
     }
 });
+contextBridge.exposeInMainWorld('_native_init', (function () {
+    window.dispatchEvent(new CustomEvent('native:init'));
+    delete window['_native_init'];
+})());

--- a/resources/js/electron-plugin/dist/server/api/menuBar.js
+++ b/resources/js/electron-plugin/dist/server/api/menuBar.js
@@ -83,9 +83,9 @@ router.post("/create", (req, res) => {
                 transparent: transparency,
                 webPreferences: {
                     preload: fileURLToPath(new URL('../../electron-plugin/dist/preload/index.mjs', import.meta.url)),
-                    nodeIntegration: true,
                     sandbox: false,
-                    contextIsolation: false,
+                    nodeIntegration: false,
+                    contextIsolation: true,
                 }
             }
         });

--- a/resources/js/electron-plugin/dist/server/api/menuBar.js
+++ b/resources/js/electron-plugin/dist/server/api/menuBar.js
@@ -51,7 +51,7 @@ router.post("/create", (req, res) => {
         state.activeMenuBar.tray.destroy();
         shouldSendCreatedEvent = false;
     }
-    const { width, height, url, label, alwaysOnTop, vibrancy, backgroundColor, transparency, icon, showDockIcon, onlyShowContextMenu, windowPosition, showOnAllWorkspaces, contextMenu, tooltip, resizable, event, } = req.body;
+    const { width, height, url, label, alwaysOnTop, vibrancy, backgroundColor, transparency, icon, showDockIcon, onlyShowContextMenu, windowPosition, showOnAllWorkspaces, contextMenu, tooltip, resizable, webPreferences, event, } = req.body;
     if (onlyShowContextMenu) {
         const tray = new Tray(icon || state.icon.replace("icon.png", "IconTemplate.png"));
         tray.setContextMenu(buildMenu(contextMenu));
@@ -81,7 +81,7 @@ router.post("/create", (req, res) => {
                 vibrancy,
                 backgroundColor,
                 transparent: transparency,
-                webPreferences: mergePreferences()
+                webPreferences: mergePreferences(webPreferences)
             }
         });
         state.activeMenuBar.on("after-create-window", () => {

--- a/resources/js/electron-plugin/dist/server/api/menuBar.js
+++ b/resources/js/electron-plugin/dist/server/api/menuBar.js
@@ -4,8 +4,8 @@ import { compileMenu } from "./helper/index.js";
 import state from "../state.js";
 import { menubar } from "menubar";
 import { notifyLaravel } from "../utils.js";
-import { fileURLToPath } from 'url';
 import { enable } from "@electron/remote/main/index.js";
+import mergePreferences from "../webPreferences.js";
 const router = express.Router();
 router.post("/label", (req, res) => {
     var _a;
@@ -81,12 +81,7 @@ router.post("/create", (req, res) => {
                 vibrancy,
                 backgroundColor,
                 transparent: transparency,
-                webPreferences: {
-                    preload: fileURLToPath(new URL('../../electron-plugin/dist/preload/index.mjs', import.meta.url)),
-                    sandbox: false,
-                    nodeIntegration: false,
-                    contextIsolation: true,
-                }
+                webPreferences: mergePreferences()
             }
         });
         state.activeMenuBar.on("after-create-window", () => {

--- a/resources/js/electron-plugin/dist/server/api/window.js
+++ b/resources/js/electron-plugin/dist/server/api/window.js
@@ -158,8 +158,8 @@ router.post('/open', (req, res) => {
         spellcheck: false,
         preload: preloadPath,
         sandbox: false,
-        contextIsolation: false,
-        nodeIntegration: true,
+        contextIsolation: true,
+        nodeIntegration: false,
     };
     let windowState = undefined;
     if (req.body.rememberState === true) {

--- a/resources/js/electron-plugin/dist/server/api/window.js
+++ b/resources/js/electron-plugin/dist/server/api/window.js
@@ -1,9 +1,9 @@
 import express from 'express';
 import { BrowserWindow } from 'electron';
 import state from '../state.js';
-import { fileURLToPath } from 'url';
 import { notifyLaravel, goToUrl, appendWindowIdToUrl } from '../utils.js';
 import windowStateKeeper from 'electron-window-state';
+import mergePreferences from '../webPreferences.js';
 import { enable } from "@electron/remote/main/index.js";
 const router = express.Router();
 router.post('/maximize', (req, res) => {
@@ -152,15 +152,6 @@ router.post('/open', (req, res) => {
         res.sendStatus(200);
         return;
     }
-    let preloadPath = fileURLToPath(new URL('../../electron-plugin/dist/preload/index.mjs', import.meta.url));
-    const defaultWebPreferences = {
-        backgroundThrottling: false,
-        spellcheck: false,
-        preload: preloadPath,
-        sandbox: false,
-        contextIsolation: true,
-        nodeIntegration: false,
-    };
     let windowState = undefined;
     if (req.body.rememberState === true) {
         windowState = windowStateKeeper({
@@ -187,7 +178,7 @@ router.post('/open', (req, res) => {
         focusable,
         skipTaskbar,
         hiddenInMissionControl,
-        autoHideMenuBar }, (process.platform === 'linux' ? { icon: state.icon } : {})), { webPreferences: Object.assign(Object.assign({}, webPreferences), defaultWebPreferences), fullscreen,
+        autoHideMenuBar }, (process.platform === 'linux' ? { icon: state.icon } : {})), { webPreferences: mergePreferences(webPreferences), fullscreen,
         fullscreenable,
         kiosk }));
     if ((process.env.NODE_ENV === 'development' || showDevTools === true) && showDevTools !== false) {

--- a/resources/js/electron-plugin/dist/server/webPreferences.js
+++ b/resources/js/electron-plugin/dist/server/webPreferences.js
@@ -1,0 +1,15 @@
+import { fileURLToPath } from 'url';
+let preloadPath = fileURLToPath(new URL('../../electron-plugin/dist/preload/index.mjs', import.meta.url));
+const defaultWebPreferences = {
+    spellcheck: false,
+    nodeIntegration: false,
+    backgroundThrottling: false,
+};
+const requiredWebPreferences = {
+    sandbox: false,
+    preload: preloadPath,
+    contextIsolation: true,
+};
+export default function (userWebPreferences = {}) {
+    return Object.assign(Object.assign(Object.assign({}, defaultWebPreferences), userWebPreferences), requiredWebPreferences);
+}

--- a/resources/js/electron-plugin/src/preload/index.mts
+++ b/resources/js/electron-plugin/src/preload/index.mts
@@ -91,7 +91,7 @@ ipcRenderer.on('native-event', (event, data) => {
 // -------------------------------------------------------------------
 // Let the client know preload is fully evaluated
 // -------------------------------------------------------------------
-contextBridge.exposeInMainWorld('_native_init', (function() {
+contextBridge.exposeInMainWorld('native:initialized', (function() {
     // This is admittedly a bit hacky. Due to context isolation
     // we don't have direct access to the renderer window object,
     // but by assigning a bridge function that executes itself inside
@@ -105,6 +105,5 @@ contextBridge.exposeInMainWorld('_native_init', (function() {
 
     window.dispatchEvent(new CustomEvent('native:init'));
 
-    // Cleanup the window property we abused
-    delete window['_native_init'];
+    return true;
 })())

--- a/resources/js/electron-plugin/src/preload/index.mts
+++ b/resources/js/electron-plugin/src/preload/index.mts
@@ -1,6 +1,9 @@
 import remote from "@electron/remote";
-import {ipcRenderer} from "electron";
+import {ipcRenderer, contextBridge} from "electron";
 
+// -------------------------------------------------------------------
+// The Native helper
+// -------------------------------------------------------------------
 const Native = {
     on: (event, callback) => {
         ipcRenderer.on('native-event', (_, data) => {
@@ -19,12 +22,11 @@ const Native = {
     }
 };
 
-// @ts-ignore
-window.Native = Native;
+contextBridge.exposeInMainWorld('Native', Native);
 
-// @ts-ignore
-window.remote = remote;
-
+// -------------------------------------------------------------------
+// Log events
+// -------------------------------------------------------------------
 ipcRenderer.on('log', (event, {level, message, context}) => {
     if (level === 'error') {
       console.error(`[${level}] ${message}`, context)
@@ -35,7 +37,10 @@ ipcRenderer.on('log', (event, {level, message, context}) => {
     }
 });
 
-// Add Livewire event listeners
+
+// -------------------------------------------------------------------
+// Livewire event listeners
+// -------------------------------------------------------------------
 ipcRenderer.on('native-event', (event, data) => {
 
   // Strip leading slashes
@@ -82,3 +87,24 @@ ipcRenderer.on('native-event', (event, data) => {
     })
   }
 })
+
+// -------------------------------------------------------------------
+// Let the client know preload is fully evaluated
+// -------------------------------------------------------------------
+contextBridge.exposeInMainWorld('_native_init', (function() {
+    // This is admittedly a bit hacky. Due to context isolation
+    // we don't have direct access to the renderer window object,
+    // but by assigning a bridge function that executes itself inside
+    // the renderer context we can hack around it.
+
+    // It's recommended to use window.postMessage & dispatch an
+    // event from the renderer itself, but we're loading webcontent
+    // from localhost. We don't have a renderer process we can access.
+    // Though this is hacky it works well and is the quickest way to do this
+    // without sprinkling additional logic all over the place.
+
+    window.dispatchEvent(new CustomEvent('native:init'));
+
+    // Cleanup the window property we abused
+    delete window['_native_init'];
+})())

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -131,9 +131,9 @@ router.post("/create", (req, res) => {
                 transparent: transparency,
                 webPreferences: {
                     preload: fileURLToPath(new URL('../../electron-plugin/dist/preload/index.mjs', import.meta.url)),
-                    nodeIntegration: true,
                     sandbox: false,
-                    contextIsolation: false,
+                    nodeIntegration: false,
+                    contextIsolation: true,
                 }
             }
         });

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -89,6 +89,7 @@ router.post("/create", (req, res) => {
         contextMenu,
         tooltip,
         resizable,
+        webPreferences,
         event,
     } = req.body;
 
@@ -130,7 +131,7 @@ router.post("/create", (req, res) => {
                 vibrancy,
                 backgroundColor,
                 transparent: transparency,
-                webPreferences: mergePreferences()
+                webPreferences: mergePreferences(webPreferences)
             }
         });
 

--- a/resources/js/electron-plugin/src/server/api/menuBar.ts
+++ b/resources/js/electron-plugin/src/server/api/menuBar.ts
@@ -6,6 +6,7 @@ import { menubar } from "menubar";
 import { notifyLaravel } from "../utils.js";
 import { fileURLToPath } from 'url'
 import { enable } from "@electron/remote/main/index.js";
+import mergePreferences from "../webPreferences.js";
 
 const router = express.Router();
 
@@ -129,12 +130,7 @@ router.post("/create", (req, res) => {
                 vibrancy,
                 backgroundColor,
                 transparent: transparency,
-                webPreferences: {
-                    preload: fileURLToPath(new URL('../../electron-plugin/dist/preload/index.mjs', import.meta.url)),
-                    sandbox: false,
-                    nodeIntegration: false,
-                    contextIsolation: true,
-                }
+                webPreferences: mergePreferences()
             }
         });
 

--- a/resources/js/electron-plugin/src/server/api/window.ts
+++ b/resources/js/electron-plugin/src/server/api/window.ts
@@ -4,6 +4,7 @@ import state from '../state.js';
 import { fileURLToPath } from 'url'
 import { notifyLaravel, goToUrl, appendWindowIdToUrl } from '../utils.js';
 import windowStateKeeper from 'electron-window-state';
+import mergePreferences from '../webPreferences.js'
 
 import {enable} from "@electron/remote/main/index.js";
 
@@ -247,17 +248,6 @@ router.post('/open', (req, res) => {
         return;
     }
 
-    let preloadPath = fileURLToPath(new URL('../../electron-plugin/dist/preload/index.mjs', import.meta.url));
-
-    const defaultWebPreferences = {
-        backgroundThrottling: false,
-        spellcheck: false,
-        preload: preloadPath,
-        sandbox: false,
-        contextIsolation: true,
-        nodeIntegration: false,
-    };
-
     let windowState: windowStateKeeper.State | undefined = undefined;
 
     if (req.body.rememberState === true) {
@@ -301,10 +291,7 @@ router.post('/open', (req, res) => {
         hiddenInMissionControl,
         autoHideMenuBar,
         ...(process.platform === 'linux' ? {icon: state.icon} : {}),
-        webPreferences: {
-            ...webPreferences,
-            ...defaultWebPreferences
-        },
+        webPreferences: mergePreferences(webPreferences),
         fullscreen,
         fullscreenable,
         kiosk,

--- a/resources/js/electron-plugin/src/server/api/window.ts
+++ b/resources/js/electron-plugin/src/server/api/window.ts
@@ -254,8 +254,8 @@ router.post('/open', (req, res) => {
         spellcheck: false,
         preload: preloadPath,
         sandbox: false,
-        contextIsolation: false,
-        nodeIntegration: true,
+        contextIsolation: true,
+        nodeIntegration: false,
     };
 
     let windowState: windowStateKeeper.State | undefined = undefined;

--- a/resources/js/electron-plugin/src/server/webPreferences.ts
+++ b/resources/js/electron-plugin/src/server/webPreferences.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'url'
+
+let preloadPath = fileURLToPath(new URL('../../electron-plugin/dist/preload/index.mjs', import.meta.url));
+
+const defaultWebPreferences = {
+    spellcheck: false,
+    nodeIntegration: false,
+    backgroundThrottling: false,
+};
+
+const requiredWebPreferences = {
+    sandbox: false,
+    preload: preloadPath,
+    contextIsolation: true,
+}
+
+export default function(userWebPreferences: object = {}): object
+{
+    return {
+        ...defaultWebPreferences,
+        ...userWebPreferences,
+        ...requiredWebPreferences
+    }
+}

--- a/resources/js/electron.vite.config.mjs
+++ b/resources/js/electron.vite.config.mjs
@@ -16,8 +16,5 @@ export default defineConfig({
             },
         },
         plugins: [externalizeDepsPlugin()]
-    },
-    preload: {
-        plugins: [externalizeDepsPlugin()]
     }
 });

--- a/resources/js/src/preload/index.js
+++ b/resources/js/src/preload/index.js
@@ -1,5 +1,0 @@
-import { electronAPI } from '@electron-toolkit/preload'
-import * as remote from '@electron/remote/index.js'
-
-window.electron = electronAPI
-window.remote = remote;


### PR DESCRIPTION
This PR improves the default security preferences & changes `preload.js` to support those changes:

- disabled node integration
- enabled context isolation (required - can't be overwritten)
- refactored preload script to use the contextBridge API
- added `native:init` event for registering Native listeners (prevents race conditions where preload hasn't evaluated yet)
- updated which of these defaults may be overwritten (`preload`, `contextIsolation` and `sandbox` cannot be changed)
- make sure Window & MenuBar use the same preferences
- added the ability to pass custom webPreferences to MenuBar windows

See https://github.com/NativePHP/laravel/issues/688 for more details

--- 

This PR also introduces a event that's called whenever the `preload` script is fully evaluated. In the past some people have reported race conditions where they register a listener with `Native.on()` but the Native object is not available yet.

This event adresses that:

``` js
document.addEventListener('native:init' function() {

    Native.on("Native\\Laravel\\Events\\Windows\\WindowBlurred", (payload, event) => {
        //
    });
})
```
